### PR TITLE
FIX: After 'dispose' call in rewind(), handleChange re-fires

### DIFF
--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -139,12 +139,16 @@ class Helmet extends React.Component {
     }
 
     static rewind() {
+        // after side-effect dispose, handle change fires again - we need to preserve variables before calling dispose.
+        const _serverTitle = serverTitle;
+        const _meta = generateTagsAsString(TAG_NAMES.META, serverMetaTags);
+        const _link = generateTagsAsString(TAG_NAMES.LINK, serverLinkTags);
         this.dispose();
 
         return {
-            title: serverTitle,
-            meta: generateTagsAsString(TAG_NAMES.META, serverMetaTags),
-            link: generateTagsAsString(TAG_NAMES.LINK, serverLinkTags)
+            title: _serverTitle,
+            meta: _meta,
+            link: _link
         };
     }
 


### PR DESCRIPTION
After 'dispose' call in rewind(), handleChange re-fires, but this time without any changes. This behaviour resets the value. FIX is to preserve the variables in rewind() method, just before calling the dispose() and using those values to return new head element.