### PR TITLE
add a titleTemplate attribute to help format document.title

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ export default class Application extends React.Component {
             <div className="application">
                 <Helmet
                     title="My Title"
+                    titleTemplate="MyAwesomeWebsite.com - %s"
                     meta={[
                         {"name": "description", "content": "Helmet application"},
                         {"property": "og:type", "content": "article"}
@@ -114,7 +115,24 @@ head.link
   </head>
   ```
 
-2. Duplicate `meta` and/or `link` tags in the same component are preserved
+2. Use a titleTemplate to format title text in your page title
+  ```javascript
+  <Helmet
+      title="My Title"
+      titleTemplate="%s | MyAwesomeWebsite.com"
+  />
+  <Helmet
+      title="Nested Title"
+  />
+  ```
+  Yields:
+  ```
+  <head>
+      <title>Nested Title | MyAwesomeWebsite.com</title>
+  </head>
+  ```
+
+3. Duplicate `meta` and/or `link` tags in the same component are preserved
   ```javascript
   <Helmet
       link={[
@@ -131,7 +149,7 @@ head.link
   </head>
   ```
 
-3. Duplicate tags can still be overwritten
+4. Duplicate tags can still be overwritten
   ```javascript
   <Helmet
       link={[

--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -6,10 +6,10 @@ import HTMLEntities from "he";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 
-const getTitleTemplateFromPropsList = (propsList) => {
+const getInnermostProperty = (propsList, property) => {
     for (const props of [...propsList].reverse()) {
-        if (props.titleTemplate) {
-            return props.titleTemplate;
+        if (props[property]) {
+            return props[property];
         }
     }
 
@@ -17,14 +17,14 @@ const getTitleTemplateFromPropsList = (propsList) => {
 };
 
 const getTitleFromPropsList = (propsList) => {
-    const innermostProps = propsList[propsList.length - 1];
-    const titleTemplate = getTitleTemplateFromPropsList(propsList);
+    const innermostTitle = getInnermostProperty(propsList, "title");
+    const innermostTemplate = getInnermostProperty(propsList, "titleTemplate");
 
-    if (titleTemplate) {
-        return titleTemplate.replace("%s", innermostProps.title || "");
+    if (innermostTemplate && innermostTitle) {
+        return innermostTemplate.replace(/\%s/g, innermostTitle);
     }
 
-    return innermostProps ? innermostProps.title : "";
+    return innermostTitle || "";
 };
 
 const getTagsFromPropsList = (tagName, uniqueTagIds, propsList) => {

--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -6,8 +6,24 @@ import HTMLEntities from "he";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 
+const getTitleTemplateFromPropsList = (propsList) => {
+    for (const props of [...propsList].reverse()) {
+        if (props.titleTemplate) {
+            return props.titleTemplate;
+        }
+    }
+
+    return null;
+};
+
 const getTitleFromPropsList = (propsList) => {
     const innermostProps = propsList[propsList.length - 1];
+    const titleTemplate = getTitleTemplateFromPropsList(propsList);
+
+    if (titleTemplate) {
+        return titleTemplate.replace("%s", innermostProps.title || "");
+    }
+
     return innermostProps ? innermostProps.title : "";
 };
 
@@ -110,6 +126,7 @@ class Helmet extends React.Component {
      */
     static propTypes = {
         title: React.PropTypes.string,
+        titleTemplate: React.PropTypes.string,
         meta: React.PropTypes.arrayOf(React.PropTypes.object),
         link: React.PropTypes.arrayOf(React.PropTypes.object),
         children: React.PropTypes.oneOfType([

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -62,6 +62,46 @@ describe("Helmet", () => {
         expect(document.title).to.equal("Nested Title");
     });
 
+    it("will use a titleTemplate if defined", () => {
+        HelmetRendered = TestUtils.renderIntoDocument(
+                <Helmet
+                    title={"Test"}
+                    titleTemplate={"This is a %s of the titleTemplate feature"}
+                />
+            );
+
+        expect(document.title).to.equal("This is a Test of the titleTemplate feature");
+    });
+
+    it("will use a titleTemplate based on deepest nested component", () => {
+        HelmetRendered = TestUtils.renderIntoDocument(
+                <Helmet
+                    title={"Test"}
+                    titleTemplate={"This is a %s of the titleTemplate feature"}
+                >
+                    <Helmet
+                        title={"Second Test"}
+                        titleTemplate={"A %s using nested titleTemplate attributes"}
+                    />
+                </Helmet>
+            );
+
+        expect(document.title).to.equal("A Second Test using nested titleTemplate attributes");
+    });
+
+    it("will merge deepest component title with nearest upstream titleTemplate", () => {
+        HelmetRendered = TestUtils.renderIntoDocument(
+                <Helmet
+                    title={"Test"}
+                    titleTemplate={"This is a %s of the titleTemplate feature"}
+                >
+                    <Helmet title={"Second Test"} />
+                </Helmet>
+            );
+
+        expect(document.title).to.equal("This is a Second Test of the titleTemplate feature");
+    });
+
     it("can update meta tags", () => {
         HelmetRendered = TestUtils.renderIntoDocument(
                 <Helmet

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -73,6 +73,17 @@ describe("Helmet", () => {
         expect(document.title).to.equal("This is a Test of the titleTemplate feature");
     });
 
+    it("will replace multiple title strings in titleTemplate", () => {
+        HelmetRendered = TestUtils.renderIntoDocument(
+                <Helmet
+                    title={"Test"}
+                    titleTemplate={"This is a %s of the titleTemplate feature. Another %s."}
+                />
+            );
+
+        expect(document.title).to.equal("This is a Test of the titleTemplate feature. Another Test.");
+    });
+
     it("will use a titleTemplate based on deepest nested component", () => {
         HelmetRendered = TestUtils.renderIntoDocument(
                 <Helmet


### PR DESCRIPTION
Feature: add a titleTemplate attribute to help format `document.title`. Text defined in this attribute will be used to augment your `document.title`. e.g.

  ```javascript
  <Helmet
      title="My Title"
      titleTemplate="%s | MyAwesomeWebsite.com"
  />
  <Helmet
      title="Nested Title"
  />
  ```
  Yields:
  ```
  <head>
      <title>Nested Title | MyAwesomeWebsite.com</title>
  </head>