### PR TITLE
Fixes case where nested components don't specify title and blank out title

### DIFF
--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -73,6 +73,10 @@ const getTagsFromPropsList = (tagName, uniqueTagIds, propsList) => {
     return tagList;
 };
 
+const updateTitle = title => {
+    document.title = title || document.title;
+};
+
 const updateTags = (type, tags) => {
     const headElement = document.head || document.querySelector("head");
     const existingTags = headElement.querySelectorAll(`${type}[${HELMET_ATTRIBUTE}]`);
@@ -141,7 +145,7 @@ class Helmet extends React.Component {
         const linkTags = getTagsFromPropsList(TAG_NAMES.LINK, [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF], propsList);
 
         if (ExecutionEnvironment.canUseDOM) {
-            document.title = title || "";
+            updateTitle(title);
             updateTags(TAG_NAMES.LINK, linkTags);
             updateTags(TAG_NAMES.META, metaTags);
         } else {

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -44,14 +44,6 @@ describe("Helmet", () => {
         expect(document.title).to.equal("Child Two Title");
     });
 
-    it("will set blank title if none is specified", () => {
-        HelmetRendered = TestUtils.renderIntoDocument(
-                <Helmet />
-            );
-
-        expect(document.title).to.equal("");
-    });
-
     it("will set title based on deepest nested component", () => {
         HelmetRendered = TestUtils.renderIntoDocument(
                 <Helmet title={"Main Title"}>
@@ -60,6 +52,16 @@ describe("Helmet", () => {
             );
 
         expect(document.title).to.equal("Nested Title");
+    });
+
+    it("will set title using deepest nested component with a defined title", () => {
+        HelmetRendered = TestUtils.renderIntoDocument(
+                <Helmet title={"Main Title"}>
+                    <Helmet />
+                </Helmet>
+            );
+
+        expect(document.title).to.equal("Main Title");
     });
 
     it("will use a titleTemplate if defined", () => {


### PR DESCRIPTION
Bugfix - Blank title in nested components would blank the title.

Test case update - Removed deprecated test case for blank title and added new test to cover blank titles in nested components.