### PR TITLE
encode title on server

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gulp-notify": "^2.2.0",
     "gulp-util": "^3.0.6",
     "isparta-instrumenter-loader": "^0.2.1",
-    "karma": "^0.12.37",
+    "karma": "^0.13.3",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.0",
     "karma-cli": "0.1.0",

--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -171,7 +171,7 @@ class Helmet extends React.Component {
     }
 
     static rewind() {
-        const title = serverTitle;
+        const title = HTMLEntities.encode(serverTitle);
         const meta = generateTagsAsString(TAG_NAMES.META, serverMetaTags);
         const link = generateTagsAsString(TAG_NAMES.LINK, serverLinkTags);
 

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -5,6 +5,8 @@ import Helmet from "../index.jsx";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 
+import ExecutionEnvironment from "exenv";
+
 describe("Helmet", () => {
     var headElement;
 
@@ -608,6 +610,23 @@ describe("Helmet", () => {
             expect(existingTag.getAttribute("name")).to.equal("description");
             expect(existingTag.getAttribute("content")).to.equal("This is \"quoted\" text and & and '.");
             expect(existingTag.outerHTML).to.equal(`<meta name="description" content="This is &quot;quoted&quot; text and &amp; and '." ${HELMET_ATTRIBUTE}="true">`);
+        });
+
+        it("will html encode title on server", () => {
+            ExecutionEnvironment.canUseDOM = false;
+
+            HelmetRendered = React.render(
+                <Helmet
+                    title="Dangerous <script> include"
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.be.equal("Dangerous &#x3C;script&#x3E; include");
+
+            ExecutionEnvironment.canUseDOM = true;
         });
     });
 });


### PR DESCRIPTION
Added so that `Helmet.rewind` will encode `title` as it does so with the rest.

Almost opened an XSS vulnerability on my site.
