### PR TITLE
Use named exports in HelmetConstants

### DIFF
--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -1,9 +1,9 @@
-const TAG_NAMES = {
+export const TAG_NAMES = {
     META: "meta",
     LINK: "link"
 };
 
-const TAG_PROPERTIES = {
+export const TAG_PROPERTIES = {
     NAME: "name",
     CHARSET: "charset",
     HTTPEQUIV: "http-equiv",
@@ -11,5 +11,3 @@ const TAG_PROPERTIES = {
     HREF: "href",
     PROPERTY: "property"
 };
-
-export default {TAG_NAMES, TAG_PROPERTIES};


### PR DESCRIPTION
You're using named exports but only exporting a default object, this is not valid ES6 module usage. It only works because currently babel sets the default export as `module.exports = default` for compatibility with CommonJS. This behavior is [deprecated](https://github.com/babel/babel/issues/2212), precisely to avoid this kind of scenario from happening.

**Helmet.jsx**

```js
import {TAG_NAMES, TAG_PROPERTIES} from "./HelmetConstants.js";
```

**HelmetConstants.js**

```js
export default {TAG_NAMES, TAG_PROPERTIES};
```

This PR updates **HelmetConstants.js** so it has two named exports.