### PR TITLE
Allow all React 0.14 betas as valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "shallowequal": "^0.2.2"
   },
   "peerDependencies": {
-    "react": ">=0.13.0 <0.15.0 || 0.14.0-beta1"
+    "react": ">=0.13.0 <0.15.0 || ^0.14.0-alpha"
   },
   "devDependencies": {
     "babel": "^5.8.21",


### PR DESCRIPTION
Taken from [react-dnd](https://github.com/gaearon/react-dnd/commit/5f8667e4f7c77af2b26ad70bade4a2303d1eb686). This allows you to use any react 0.14 beta. The current release only lets you use 0.14.0-beta1, yet the latest beta is 0.14.0-beta3.