### PR TITLE
handleClientStateChange does deep-equal check to prevent unnecessary …

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "core-js": "^1.1.1",
+    "deep-equal": "^1.0.0",
     "he": "^0.5.0",
     "invariant": "^2.1.0",
     "react-side-effect": "^1.0.0",

--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -197,7 +197,7 @@ const mapStateOnServer = ({title, metaTags, linkTags}) => ({
     link: generateTagsAsString(TAG_NAMES.LINK, linkTags)
 });
 
-export {Helmet as HelmetUnwrapped};
+export {Helmet as HelmetComponent};
 export default withSideEffect(
     reducePropsToState,
     handleClientStateChange,

--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import withSideEffect from "react-side-effect";
+import deepEqual from "deep-equal";
 import {TAG_NAMES, TAG_PROPERTIES} from "./HelmetConstants.js";
 import HTMLEntities from "he";
 
@@ -127,24 +128,6 @@ const generateTagsAsString = (type, tags) => {
     return html.join("\n");
 };
 
-const reducePropsToState = (propsList) => ({
-    title: getTitleFromPropsList(propsList),
-    metaTags: getTagsFromPropsList(TAG_NAMES.META, [TAG_PROPERTIES.NAME, TAG_PROPERTIES.CHARSET, TAG_PROPERTIES.HTTPEQUIV], propsList),
-    linkTags: getTagsFromPropsList(TAG_NAMES.LINK, [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF], propsList)
-});
-
-const handleClientStateChange = ({title, metaTags, linkTags}) => {
-    updateTitle(title);
-    updateTags(TAG_NAMES.LINK, linkTags);
-    updateTags(TAG_NAMES.META, metaTags);
-};
-
-const mapStateOnServer = ({title, metaTags, linkTags}) => ({
-    title: HTMLEntities.encode(title),
-    meta: generateTagsAsString(TAG_NAMES.META, metaTags),
-    link: generateTagsAsString(TAG_NAMES.LINK, linkTags)
-});
-
 class Helmet extends React.Component {
     /**
      * @param {Object} title: "Title"
@@ -162,6 +145,14 @@ class Helmet extends React.Component {
         ])
     }
 
+    shouldComponentUpdate(nextProps) {
+        return !deepEqual(this.props, nextProps);
+    }
+
+    static onDOMChange(newState) {
+        return newState;
+    }
+
     render() {
         if (Object.is(React.Children.count(this.props.children), 1)) {
             return React.Children.only(this.props.children);
@@ -177,6 +168,36 @@ class Helmet extends React.Component {
     }
 }
 
+const reducePropsToState = (propsList) => ({
+    title: getTitleFromPropsList(propsList),
+    metaTags: getTagsFromPropsList(TAG_NAMES.META, [TAG_PROPERTIES.NAME, TAG_PROPERTIES.CHARSET, TAG_PROPERTIES.HTTPEQUIV], propsList),
+    linkTags: getTagsFromPropsList(TAG_NAMES.LINK, [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF], propsList)
+});
+
+let clientState;
+const handleClientStateChange = (newState) => {
+    if (deepEqual(clientState, newState)) {
+        return;
+    }
+
+    const {title, metaTags, linkTags} = newState;
+    updateTitle(title);
+    updateTags(TAG_NAMES.LINK, linkTags);
+    updateTags(TAG_NAMES.META, metaTags);
+
+    Helmet.onDOMChange(newState);
+
+    // Caching state in order to check if client state should be updated
+    clientState = newState;
+};
+
+const mapStateOnServer = ({title, metaTags, linkTags}) => ({
+    title: HTMLEntities.encode(title),
+    meta: generateTagsAsString(TAG_NAMES.META, metaTags),
+    link: generateTagsAsString(TAG_NAMES.LINK, linkTags)
+});
+
+export {Helmet as HelmetUnwrapped};
 export default withSideEffect(
     reducePropsToState,
     handleClientStateChange,

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -661,5 +661,35 @@ describe("Helmet", () => {
                 done();
             }, 1000);
         });
+
+        it("will not update the DOM when nested Helmets have props that are identical", (done) => {
+            const old = HelmetComponent.onDOMChange;
+            let changesToDOM = 0;
+            HelmetComponent.onDOMChange = (state) => {
+                changesToDOM++;
+                return old(state);
+            };
+
+            React.render(
+                <Helmet
+                    title={"Test Title"}
+                    meta={[{"name": "description", "content": "Test description"}]}
+                >
+                    <div>
+                        <Helmet
+                            title={"Test Title"}
+                            meta={[{"name": "description", "content": "Test description"}]}
+                        />
+                    </div>
+                </Helmet>,
+                container
+            );
+
+            setTimeout(() => {
+                expect(changesToDOM).to.equal(1);
+                HelmetComponent.onDOMChange = old;
+                done();
+            }, 1000);
+        });
     });
 });

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -2,7 +2,7 @@
 
 import React from "react/addons";
 import Helmet from "../index";
-import {HelmetUnwrapped} from "../Helmet";
+import {HelmetComponent} from "../Helmet";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 
@@ -631,11 +631,11 @@ describe("Helmet", () => {
         });
 
         it("will not update the DOM if updated props are unchanged", (done) => {
-            const old = HelmetUnwrapped.onDOMChange;
+            const old = HelmetComponent.onDOMChange;
             let changesToDOM = 0;
-            HelmetUnwrapped.onDOMChange = (state) => {
+            HelmetComponent.onDOMChange = (state) => {
                 changesToDOM++;
-                return state;
+                return old(state);
             };
 
             React.render(
@@ -657,7 +657,7 @@ describe("Helmet", () => {
 
             setTimeout(() => {
                 expect(changesToDOM).to.equal(1);
-                HelmetUnwrapped.onDOMChange = old;
+                HelmetComponent.onDOMChange = old;
                 done();
             }, 1000);
         });

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -2,6 +2,7 @@
 
 import React from "react/addons";
 import Helmet from "../index";
+import {HelmetUnwrapped} from "../Helmet";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 
@@ -627,6 +628,38 @@ describe("Helmet", () => {
             expect(head.title).to.be.equal("Dangerous &#x3C;script&#x3E; include");
 
             Helmet.canUseDOM = true;
+        });
+
+        it("will not update the DOM if updated props are unchanged", (done) => {
+            const old = HelmetUnwrapped.onDOMChange;
+            let changesToDOM = 0;
+            HelmetUnwrapped.onDOMChange = (state) => {
+                changesToDOM++;
+                return state;
+            };
+
+            React.render(
+                <Helmet
+                    title={"Test Title"}
+                    meta={[{"name": "description", "content": "Test description"}]}
+                />,
+                container
+            );
+
+            // Re-rendering will pass new props to an already mounted Helmet
+            React.render(
+                <Helmet
+                    title={"Test Title"}
+                    meta={[{"name": "description", "content": "Test description"}]}
+                />,
+                container
+            );
+
+            setTimeout(() => {
+                expect(changesToDOM).to.equal(1);
+                HelmetUnwrapped.onDOMChange = old;
+                done();
+            }, 1000);
         });
     });
 });


### PR DESCRIPTION
…DOM changes

Also added deep-equal check to Helmet to prevent unnecessary re-renders.
Updated unit tests to check for DOM Changes, utilizing new static onDOMChange function added to Helmet.