### PR TITLE
Enforce react-side-effect@1.0.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deep-equal": "^1.0.0",
     "he": "^0.5.0",
     "invariant": "^2.1.0",
-    "react-side-effect": "^1.0.0",
+    "react-side-effect": "^1.0.1",
     "shallowequal": "^0.2.2",
     "warning": "^2.0.0"
   },


### PR DESCRIPTION
This is necessary because 1.0.0 has a memory leak.
https://github.com/gaearon/react-side-effect/pull/10