### PR TITLE
Bump react-side-effect version floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deep-equal": "^1.0.1",
     "he": "^0.5.0",
     "invariant": "^2.1.0",
-    "react-side-effect": "^1.0.1",
+    "react-side-effect": "^1.0.2",
     "shallowequal": "^0.2.2",
     "warning": "^2.0.0"
   },


### PR DESCRIPTION
People that reinstall react-helmet should receive the latest version of react-side-effect, so you shouldn't need to push out a new version, but bumping the version floor makes it clear that you don't expect someone to have react-side-effect <1.0.2

Closes #42 