### PR TITLE
Return meta & link tags as React components on the server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
 - '0.12'
 - '0.10'
+- 'latest'
 
 before_install:
 - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
 - '0.12'
 - '0.10'
-- 'latest'
+- 'stable'
 
 before_install:
 - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ npm install --save react-helmet
 ```
 
 ## Server Usage
-To use on the server, call `rewind()` after `React.renderToString` to get all the head changes to use in your prerender.
+To use on the server, call `rewind()` after `React.renderToString` or `React.renderToStaticMarkup` to get the head data for use in your prerender.
+
 ```javascript
 React.renderToString(<Handler />);
 let head = Helmet.rewind();
@@ -90,6 +91,11 @@ head.title
 head.meta
 head.link
 ```
+
+`head` contains three properties, `title`, `meta`, and `link`:
+
+- `title` returns a string.
+- Both `meta` and `link` return an array of React components. Both support a `toString()` method if you need a stringified value of either property.
 
 **Note:** Because this component tracks mounted instances you will need to call rewind on the server to avoid a memory leak.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "Specify the page title, meta & link tags per component in a nested fashion",
-  "version": "1.1.5",
+  "version": "2.0.0",
   "main": "./dist/index.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [
@@ -26,23 +26,20 @@
     "core-js": "^1.1.4",
     "deep-equal": "^1.0.1",
     "he": "^0.5.0",
-    "invariant": "^2.1.0",
+    "invariant": "^2.1.1",
     "react-side-effect": "^1.0.2",
     "shallowequal": "^0.2.2",
     "warning": "^2.0.0"
-  },
-  "peerDependencies": {
-    "react": ">=0.13.0 <0.15.0 || ^0.14.0-alpha || ^0.14.0-rc1"
   },
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",
-    "chai": "^3.2.0",
+    "chai": "^3.3.0",
     "chalk": "^1.1.1",
     "del": "^2.0.2",
-    "eslint": "^1.5.0",
-    "eslint-config-nfl": "^4.0.1",
+    "eslint": "^1.5.1",
+    "eslint-config-nfl": "^4.0.2",
     "eslint-plugin-react": "^3.4.2",
     "gulp": "^3.9.0",
     "gulp-cached": "^1.1.0",
@@ -52,7 +49,7 @@
     "gulp-notify": "^2.2.0",
     "gulp-util": "^3.0.6",
     "isparta-instrumenter-loader": "^0.2.1",
-    "karma": "^0.13.9",
+    "karma": "^0.13.10",
     "karma-chai": "^0.1.0",
     "karma-chai-sinon": "^0.1.5",
     "karma-chrome-launcher": "^0.2.0",
@@ -66,10 +63,10 @@
     "karma-spec-reporter": "0.0.20",
     "karma-tap-reporter": "0.0.4",
     "karma-webpack": "^1.7.0",
-    "mocha": "^2.3.2",
+    "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
     "react": "^0.13.x",
-    "sinon": "^1.16.1",
+    "sinon": "^1.17.0",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.12.2"
   },
@@ -78,6 +75,7 @@
     "lint": "gulp eslint",
     "test": "karma start karma.config.js",
     "posttest": "cat ./build/reports/coverage/text.txt",
+    "pretest": "npm run clean && npm run lint && npm run compile",
     "compile": "babel src --out-dir dist",
     "prepublish": "npm run compile"
   }

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -11,3 +11,8 @@ export const TAG_PROPERTIES = {
     HREF: "href",
     PROPERTY: "property"
 };
+
+export const REACT_TAG_MAP = {
+    "charset": "charSet",
+    "http-equiv": "httpEquiv"
+};

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -562,6 +562,163 @@ describe("Helmet", () => {
         });
     });
 
+    describe("server", () => {
+        const stringifiedMetaTags = [
+            `<meta ${HELMET_ATTRIBUTE}="true" property="og:type" content="article">`,
+            `<meta ${HELMET_ATTRIBUTE}="true" http-equiv="content-type" content="text/html">`,
+            `<meta ${HELMET_ATTRIBUTE}="true" name="description" content="Test description">`,
+            `<meta ${HELMET_ATTRIBUTE}="true" charset="utf-8">`
+        ].join("");
+
+        const stringifiedLinkTags = [
+            `<link ${HELMET_ATTRIBUTE}="true" href="http://localhost/style.css" rel="stylesheet" type="text/css">`,
+            `<link ${HELMET_ATTRIBUTE}="true" href="http://localhost/helmet" rel="canonical">`
+        ].join("");
+
+        before(() => {
+            Helmet.canUseDOM = false;
+        });
+
+        it("will html encode title", () => {
+            React.render(
+                <Helmet
+                    title="Dangerous <script> include"
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.equal("Dangerous &#x3C;script&#x3E; include");
+        });
+
+        it("will render meta tags as React components", () => {
+            React.render(
+                <Helmet
+                    meta={[
+                        {"charset": "utf-8"},
+                        {"name": "description", "content": "Test description"},
+                        {"http-equiv": "content-type", "content": "text/html"},
+                        {"property": "og:type", "content": "article"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.meta).to.exist;
+
+            expect(head.meta)
+                .to.be.an("array")
+                .that.has.length.of(4);
+
+            head.meta.forEach(meta => {
+                expect(meta)
+                    .to.be.an("object")
+                    .that.contains.property("type", "meta");
+            });
+
+            const markup = React.renderToStaticMarkup(
+                <div>
+                    {head.meta}
+                </div>
+            );
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedMetaTags
+                }</div>`);
+        });
+
+        it("will render link tags as React components", () => {
+            React.render(
+                <Helmet
+                    link={[
+                        {"href": "http://localhost/helmet", "rel": "canonical"},
+                        {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.link).to.exist;
+            expect(head.link)
+                .to.be.an("array")
+                .that.has.length.of(2);
+
+            head.link.forEach(link => {
+                expect(link)
+                    .to.be.an("object")
+                    .that.contains.property("type", "link");
+            });
+
+            const markup = React.renderToStaticMarkup(
+                <div>
+                    {head.link}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedLinkTags
+                }</div>`);
+        });
+
+        it("supports meta.tags.toString()", () => {
+            React.render(
+                <Helmet
+                    meta={[
+                        {"charset": "utf-8"},
+                        {"name": "description", "content": "Test description"},
+                        {"http-equiv": "content-type", "content": "text/html"},
+                        {"property": "og:type", "content": "article"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.meta).to.respondTo("toString");
+
+            const metaToString = head.meta.toString();
+
+            expect(metaToString)
+                .to.be.a("string")
+                .that.equals(stringifiedMetaTags);
+        });
+
+        it("supports meta.link.toString()", () => {
+            React.render(
+                <Helmet
+                    link={[
+                        {"href": "http://localhost/helmet", "rel": "canonical"},
+                        {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.link).to.respondTo("toString");
+
+            const linkToString = head.link.toString();
+
+            expect(linkToString)
+                .to.be.a("string")
+                .that.equals(stringifiedLinkTags);
+        });
+
+        after(() => {
+            Helmet.canUseDOM = true;
+        });
+    });
+
     describe("misc", () => {
         it("throws in rewind() when a DOM is present", () => {
             React.render(
@@ -614,23 +771,6 @@ describe("Helmet", () => {
             expect(existingTag.getAttribute("name")).to.equal("description");
             expect(existingTag.getAttribute("content")).to.equal("This is \"quoted\" text and & and '.");
             expect(existingTag.outerHTML).to.equal(`<meta name="description" content="This is &quot;quoted&quot; text and &amp; and '." ${HELMET_ATTRIBUTE}="true">`);
-        });
-
-        it("will html encode title on server", () => {
-            Helmet.canUseDOM = false;
-
-            React.render(
-                <Helmet
-                    title="Dangerous <script> include"
-                />,
-                container
-            );
-
-            const head = Helmet.rewind();
-
-            expect(head.title).to.be.equal("Dangerous &#x3C;script&#x3E; include");
-
-            Helmet.canUseDOM = true;
         });
 
         it("will not update the DOM if updated props are unchanged", (done) => {

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -668,7 +668,7 @@ describe("Helmet", () => {
                 }</div>`);
         });
 
-        it("supports meta.tags.toString()", () => {
+        it("supports head.meta.toString()", () => {
             React.render(
                 <Helmet
                     meta={[
@@ -692,7 +692,7 @@ describe("Helmet", () => {
                 .that.equals(stringifiedMetaTags);
         });
 
-        it("supports meta.link.toString()", () => {
+        it("supports head.link.toString()", () => {
             React.render(
                 <Helmet
                     link={[


### PR DESCRIPTION
This PR makes Helmet return meta / link tags as React components for server use.

Usage:

```javascript
React.renderToString(<Handler />);
let head = Helmet.rewind();

head.title // string
head.meta // react component
head.link // react component
```

And on the server:

```javascript
render() {
  return (
    <html>
      <head>
        <title>{head.title}</title>
        {head.meta}
        {head.link}
      </head>
      ...
    </html>
  )
}
```

The old behavior (return as stringified content) is available for legacy use:

```javascript
const stringifiedMeta = head.meta.toString(); // <meta charset="utf-8">
```

See #25 

