### PR TITLE
Strict wrapping of Helmet

### DIFF
--- a/src/PlainComponent.jsx
+++ b/src/PlainComponent.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default class PlainComponent extends React.Component {
+    static reducePropsToStateCallback(propsList) {
+        return propsList;
+    }
+
+    static handleClientStateChangeCallback(newState) {
+        return newState;
+    }
+
+    render() {
+        return null;
+    }
+}


### PR DESCRIPTION
Maintained order of tags on server and updated server test cases to match
Fixed some test cases where props were invalid

Changed naming of component to PlainComponent
Removed unneeded getter for canUseDOM
Added callbacks to PlainComponent for unit testing.
Updated unit tests with new callbacks. And added a test for nested Helmets.

Decorated component from react-side-effect, now wrapped by Helmet in order to enforce deep equal check on shouldComponentUpdate. This will limit unnecessary DOM changes and rendering.