### PR TITLE
Encode only special characters instead of all characters that have HTML-entity equivalents

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "core-js": "^1.2.1",
     "deep-equal": "^1.0.1",
-    "he": "^0.5.0",
     "invariant": "^2.1.1",
     "react-side-effect": "^1.0.2",
     "shallowequal": "^0.2.2",

--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -6,10 +6,19 @@ import {
     TAG_PROPERTIES,
     REACT_TAG_MAP
 } from "./HelmetConstants.js";
-import HTMLEntities from "he";
 import PlainComponent from "./PlainComponent";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
+
+const encodeSpecialCharacters = (str) => {
+    return String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;")
+            .replace(/`/g, "&#x60;");
+};
 
 const getInnermostProperty = (propsList, property) => {
     for (const props of [...propsList].reverse()) {
@@ -139,9 +148,7 @@ const updateTags = (type, tags) => {
 };
 
 const generateTitleAsString = (type, title) => {
-    const stringifiedMarkup = `<${type} ${HELMET_ATTRIBUTE}="true">${HTMLEntities.encode(title, {
-        useNamedReferences: true
-    })}</${type}>`;
+    const stringifiedMarkup = `<${type} ${HELMET_ATTRIBUTE}="true">${encodeSpecialCharacters(title)}</${type}>`;
 
     return stringifiedMarkup;
 };
@@ -150,9 +157,7 @@ const generateTagsAsString = (type, tags) => {
     const stringifiedMarkup = tags.map(tag => {
         const attributeHtml = Object.keys(tag)
             .map((attribute) => {
-                const encodedValue = HTMLEntities.encode(tag[attribute], {
-                    useNamedReferences: true
-                });
+                const encodedValue = encodeSpecialCharacters(tag[attribute]);
                 return `${attribute}="${encodedValue}"`;
             })
             .join(" ");
@@ -189,9 +194,7 @@ const generateTagsAsReactComponent = (type, tags) => {
         Object.keys(tag).forEach((attribute) => {
             const mappedAttribute = REACT_TAG_MAP[attribute] || attribute;
 
-            mappedTag[mappedAttribute] = HTMLEntities.encode(tag[attribute], {
-                useNamedReferences: true
-            });
+            mappedTag[mappedAttribute] = encodeSpecialCharacters(tag[attribute]);
         });
 
         return React.createElement(type, mappedTag);

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -1091,6 +1091,27 @@ describe("Helmet", () => {
                 .that.equals(stringifiedScriptTags);
         });
 
+        it("will allow non-latin character sets", () => {
+            const chineseTitle = "膣膗 鍆錌雔";
+            const stringifiedChineseTitle = `<title ${HELMET_ATTRIBUTE}="true">${chineseTitle}</title>`;
+
+            ReactDOM.render(
+                <div>
+                    <Helmet title={chineseTitle} />
+                </div>,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toString");
+
+            expect(head.title.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedChineseTitle);
+        });
+
         after(() => {
             Helmet.canUseDOM = true;
         });

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -125,6 +125,19 @@ describe("Helmet", () => {
 
                 expect(document.title).to.equal("This is a Second Test of the titleTemplate feature");
             });
+
+            it("will not encode all characters with HTML character entity equivalents", () => {
+                const chineseTitle = "膣膗 鍆錌雔";
+
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={chineseTitle} />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal(chineseTitle);
+            });
         });
 
         describe("base tag", () => {
@@ -1091,7 +1104,7 @@ describe("Helmet", () => {
                 .that.equals(stringifiedScriptTags);
         });
 
-        it("will allow non-latin character sets", () => {
+        it("will not encode all characters with HTML character entity equivalents", () => {
             const chineseTitle = "膣膗 鍆錌雔";
             const stringifiedChineseTitle = `<title ${HELMET_ATTRIBUTE}="true">${chineseTitle}</title>`;
 


### PR DESCRIPTION
Encode only special characters instead of all characters that have HTML-entity equivalents.
 - [x] Unit test with Chinese Lorem Ipsum on server side for issue #25 
 - [x] Unit test with Chinese Lorem Ipsum on client-side 
 - [x] Removes npm he in favor of regex for special characters only

