### PR TITLE
Encode only special characters / Fix for Chinese character encoding 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [2.1.1](#211)
 - [2.1.0](#210)
 - [2.0.0](#200)
 - [1.1.5](#115)
@@ -14,6 +15,13 @@
 - [1.0.0](#100)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+## 2.1.1
+
+Bugfixes:
+
+  - Remove npm he dependency
+  - HTML entitiy encode only special characters instead of all characters that have HTML entity equivalents
+
 ## 2.1.0
 
 Features:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "./dist/index.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [
@@ -27,7 +27,6 @@
   "dependencies": {
     "core-js": "^1.2.1",
     "deep-equal": "^1.0.1",
-    "he": "^0.5.0",
     "invariant": "^2.1.1",
     "react-side-effect": "^1.0.2",
     "shallowequal": "^0.2.2",

--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -6,10 +6,19 @@ import {
     TAG_PROPERTIES,
     REACT_TAG_MAP
 } from "./HelmetConstants.js";
-import HTMLEntities from "he";
 import PlainComponent from "./PlainComponent";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
+
+const encodeSpecialCharacters = (str) => {
+    return String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;")
+            .replace(/`/g, "&#x60;");
+};
 
 const getInnermostProperty = (propsList, property) => {
     for (const props of [...propsList].reverse()) {
@@ -139,9 +148,7 @@ const updateTags = (type, tags) => {
 };
 
 const generateTitleAsString = (type, title) => {
-    const stringifiedMarkup = `<${type} ${HELMET_ATTRIBUTE}="true">${HTMLEntities.encode(title, {
-        useNamedReferences: true
-    })}</${type}>`;
+    const stringifiedMarkup = `<${type} ${HELMET_ATTRIBUTE}="true">${encodeSpecialCharacters(title)}</${type}>`;
 
     return stringifiedMarkup;
 };
@@ -150,9 +157,7 @@ const generateTagsAsString = (type, tags) => {
     const stringifiedMarkup = tags.map(tag => {
         const attributeHtml = Object.keys(tag)
             .map((attribute) => {
-                const encodedValue = HTMLEntities.encode(tag[attribute], {
-                    useNamedReferences: true
-                });
+                const encodedValue = encodeSpecialCharacters(tag[attribute]);
                 return `${attribute}="${encodedValue}"`;
             })
             .join(" ");
@@ -189,9 +194,7 @@ const generateTagsAsReactComponent = (type, tags) => {
         Object.keys(tag).forEach((attribute) => {
             const mappedAttribute = REACT_TAG_MAP[attribute] || attribute;
 
-            mappedTag[mappedAttribute] = HTMLEntities.encode(tag[attribute], {
-                useNamedReferences: true
-            });
+            mappedTag[mappedAttribute] = encodeSpecialCharacters(tag[attribute]);
         });
 
         return React.createElement(type, mappedTag);

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -125,6 +125,19 @@ describe("Helmet", () => {
 
                 expect(document.title).to.equal("This is a Second Test of the titleTemplate feature");
             });
+
+            it("will not encode all characters with HTML character entity equivalents", () => {
+                const chineseTitle = "膣膗 鍆錌雔";
+
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={chineseTitle} />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal(chineseTitle);
+            });
         });
 
         describe("base tag", () => {
@@ -1089,6 +1102,27 @@ describe("Helmet", () => {
             expect(head.script.toString())
                 .to.be.a("string")
                 .that.equals(stringifiedScriptTags);
+        });
+
+        it("will not encode all characters with HTML character entity equivalents", () => {
+            const chineseTitle = "膣膗 鍆錌雔";
+            const stringifiedChineseTitle = `<title ${HELMET_ATTRIBUTE}="true">${chineseTitle}</title>`;
+
+            ReactDOM.render(
+                <div>
+                    <Helmet title={chineseTitle} />
+                </div>,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toString");
+
+            expect(head.title.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedChineseTitle);
         });
 
         after(() => {


### PR DESCRIPTION
Encode only special characters instead of all characters that have HTML-entity equivalents.
 - [x] Unit test with Chinese Lorem Ipsum on server side for issue #25 
 - [x] Unit test with Chinese Lorem Ipsum on client-side 
 - [x] Removes npm he in favor of regex for special characters only
