### PR TITLE
Adds onChangeClientState callback prop

### DIFF
--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -40,6 +40,10 @@ const getTitleFromPropsList = (propsList) => {
     return innermostTitle || "";
 };
 
+const getOnChangeClientState = (propsList) => {
+    return getInnermostProperty(propsList, "onChangeClientState") || () => {};
+};
+
 const getBaseTagFromPropsList = (validTags, propsList) => {
     return propsList
         .filter(props => !Object.is(typeof props[TAG_NAMES.BASE], "undefined"))
@@ -209,6 +213,7 @@ const Helmet = (Component) => {
     class HelmetWrapper extends React.Component {
         /**
          * @param {String} title: "Title"
+         * @param {Function} onChangeClientState: "(newState) => console.log(newState)"
          * @param {String} titleTemplate: "MySite.com - %s"
          * @param {Object} base: {"target": "_blank", "href": "http://mysite.com/"}
          * @param {Array} meta: [{"name": "description", "content": "Test description"}]
@@ -217,6 +222,7 @@ const Helmet = (Component) => {
          */
         static propTypes = {
             title: React.PropTypes.string,
+            onChangeClientState: React.PropTypes.func,
             titleTemplate: React.PropTypes.string,
             base: React.PropTypes.object,
             meta: React.PropTypes.arrayOf(React.PropTypes.object),
@@ -249,6 +255,7 @@ const reducePropsToState = (propsList) => {
 
     return {
         title: getTitleFromPropsList(propsList),
+        onChangeClientState: getOnChangeClientState(propsList),
         baseTag: getBaseTagFromPropsList([TAG_PROPERTIES.HREF], propsList),
         metaTags: getTagsFromPropsList(TAG_NAMES.META, [TAG_PROPERTIES.NAME, TAG_PROPERTIES.CHARSET, TAG_PROPERTIES.HTTPEQUIV, TAG_PROPERTIES.PROPERTY], propsList),
         linkTags: getTagsFromPropsList(TAG_NAMES.LINK, [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF], propsList),
@@ -257,13 +264,15 @@ const reducePropsToState = (propsList) => {
 };
 
 const handleClientStateChange = (newState) => {
-    const {title, baseTag, metaTags, linkTags, scriptTags} = newState;
+    const {title, baseTag, metaTags, linkTags, scriptTags, onChangeClientState} = newState;
 
     updateTitle(title);
     updateTags(TAG_NAMES.SCRIPT, scriptTags);
     updateTags(TAG_NAMES.LINK, linkTags);
     updateTags(TAG_NAMES.META, metaTags);
     updateTags(TAG_NAMES.BASE, baseTag);
+
+    onChangeClientState(newState);
 
     PlainComponent.handleClientStateChangeCallback(newState);
 };

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -140,6 +140,48 @@ describe("Helmet", () => {
             });
         });
 
+        describe("onChangeClientState", () => {
+            it("calls the function with new state when handling client state change", () => {
+                const spy = sinon.spy();
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            title={"Main Title"}
+                            base={{"href": "http://mysite.com/"}}
+                            meta={[{"charset": "utf-8"}]}
+                            link={[{"href": "http://localhost/helmet", "rel": "canonical"}]}
+                            script={[{"src": "http://localhost/test.js", "type": "text/javascript"}]}
+                            onChangeClientState={spy}
+                        />
+                    </div>,
+                    container
+                );
+
+                expect(spy.called).to.equal(true);
+                const args = spy.getCall(0).args[0];
+                expect(args).to.contain({title: "Main Title"});
+                expect(args.baseTag).to.contain({href: "http://mysite.com/"});
+                expect(args.metaTags).to.contain({"charset": "utf-8"});
+                expect(args.linkTags).to.contain({"href": "http://localhost/helmet", "rel": "canonical"});
+                expect(args.scriptTags).to.contain({"src": "http://localhost/test.js", "type": "text/javascript"});
+            });
+
+            it("calls the deepest defined callback with the deepest state", () => {
+                const spy = sinon.spy();
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={"Main Title"} onChangeClientState={spy} />
+                        <Helmet title={"Deeper Title"} />
+                    </div>,
+                    container
+                );
+
+                expect(spy.callCount).to.equal(2);
+                expect(spy.getCall(0).args[0]).to.contain({title: "Main Title"});
+                expect(spy.getCall(1).args[0]).to.contain({title: "Deeper Title"});
+            });
+        });
+
         describe("base tag", () => {
             it("can update base tag", () => {
                 ReactDOM.render(


### PR DESCRIPTION
This adds an optional `onUpdateTitle` callback that is invoked whenever the page title is updated. One use case for this would be to enable an accessibility library like this https://github.com/patrickfox/a11y_kit to hook into title changes and announce them to a screen reader, making page transitions more accessible (inspired by https://github.com/Robdel12/a11y-announcer).

It accomplishes this by calling `onUpdateTitle(document.title);` in the internal `updateTitle()` function in `Helmet.jsx`.

If folks like this approach, I'm happy to update the documentation and add callbacks to the other attributes that react-helmet can update (`base`, `meta`, etc), although I don't have use-cases in mind for those.