### PR TITLE
Fix encoding bug when rendering to React components

### DIFF
--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -195,7 +195,7 @@ const generateTagsAsReactComponent = (type, tags) => {
         Object.keys(tag).forEach((attribute) => {
             const mappedAttribute = REACT_TAG_MAP[attribute] || attribute;
 
-            mappedTag[mappedAttribute] = encodeSpecialCharacters(tag[attribute]);
+            mappedTag[mappedAttribute] = tag[attribute];
         });
 
         return React.createElement(type, mappedTag);

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -768,7 +768,7 @@ describe("Helmet", () => {
 
         const stringifiedMetaTags = [
             `<meta ${HELMET_ATTRIBUTE}="true" charset="utf-8"/>`,
-            `<meta ${HELMET_ATTRIBUTE}="true" name="description" content="Test description"/>`,
+            `<meta ${HELMET_ATTRIBUTE}="true" name="description" content="Test description &amp; encoding"/>`,
             `<meta ${HELMET_ATTRIBUTE}="true" http-equiv="content-type" content="text/html"/>`,
             `<meta ${HELMET_ATTRIBUTE}="true" property="og:type" content="article"/>`
         ].join("");
@@ -884,7 +884,7 @@ describe("Helmet", () => {
                 <Helmet
                     meta={[
                         {"charset": "utf-8"},
-                        {"name": "description", "content": "Test description"},
+                        {"name": "description", "content": "Test description & encoding"},
                         {"http-equiv": "content-type", "content": "text/html"},
                         {"property": "og:type", "content": "article"}
                     ]}
@@ -1044,7 +1044,7 @@ describe("Helmet", () => {
                 <Helmet
                     meta={[
                         {"charset": "utf-8"},
-                        {"name": "description", "content": "Test description"},
+                        {"name": "description", "content": "Test description & encoding"},
                         {"http-equiv": "content-type", "content": "text/html"},
                         {"property": "og:type", "content": "article"}
                     ]}


### PR DESCRIPTION
Previously, meta tag values were encoded before being passed to `React.createElement`. This caused the values to be double-encoded because React already encodes when rendering. This change removes the manual encoding step when converting tags to React elements so that React can properly encode at render time.