### PR TITLE
Exporting PlainComponent for use in setting callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ export default class Application extends React.Component {
 - Nested components override duplicate head changes.
 - Duplicate head changes preserved when specified in same component (support for tags like "apple-touch-icon").
 - Only valid `base`/`meta`/`link`/`script` key names allowed.
+- Ability to set callbacks for when the DOM changes or when Helmet is mounted/updated/unmounted
 
 ## Installation
 ```
@@ -235,6 +236,24 @@ class HTML extends React.Component {
   <head>
       <base href="http://mysite.com/blog">
   </head>
+  ```
+
+6. Setting callbacks to know when Helmet changes the DOM or whenever Helmet is mounted, updated, or unmounted
+
+  Import `PlainComponent`:
+  ```javascript
+  import Helmet, {PlainComponent} from "react-helmet";
+  ```
+
+  In whichever lifecycle event fits your use case, you can pass in a callback using the setter function provided in `PlainComponent` (NOTE: this is a static function):
+  ```javascript
+  PlainComponent.setReducePropsToStateCallback((propsList) => {
+      // propsList.title, propsList.link, etc. available to take action on props passed to Helmet when any instance is mounted, updated, or unmounted
+  });
+
+  PlainComponent.setClientStateChangeCallback((newState) => {
+      // newState.title, newState.link, etc. available to take action on the latest DOM changes
+  });
   ```
 
 ## Contributing to this project

--- a/src/PlainComponent.jsx
+++ b/src/PlainComponent.jsx
@@ -9,6 +9,14 @@ export default class PlainComponent extends React.Component {
         return newState;
     }
 
+    static setReducePropsToStateCallback(callback) {
+        this.reducePropsToStateCallback = callback;
+    }
+
+    static setClientStateChangeCallback(callback) {
+        this.handleClientStateChangeCallback = callback;
+    }
+
     render() {
         return null;
     }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,5 +6,7 @@ import "core-js/fn/object/is";
 import "core-js/fn/object/keys";
 import "core-js/fn/set";
 import Helmet from "./Helmet";
+import {PlainComponent} from "./Helmet";
 
+export {PlainComponent};
 export default Helmet;

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -3,8 +3,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import ReactServer from "react-dom/server";
-import Helmet from "../index";
-import {PlainComponent} from "../Helmet";
+import Helmet, {PlainComponent} from "../index";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 
@@ -1186,20 +1185,16 @@ describe("Helmet", () => {
         });
 
         it("will not call reducePropsToState or handleClientStateChange if updated props are unchanged", (done) => {
-            const oldHCSCC = PlainComponent.handleClientStateChangeCallback;
-            const oldRPSC = PlainComponent.reducePropsToStateCallback;
             let reducePropsToStateCount = 0;
             let handleClientStateChangeCount = 0;
 
-            PlainComponent.reducePropsToStateCallback = (state) => {
-                reducePropsToStateCount++;
-                return oldRPSC(state);
-            };
-
-            PlainComponent.handleClientStateChangeCallback = (state) => {
+            PlainComponent.setClientStateChangeCallback(() => {
                 handleClientStateChangeCount++;
-                return oldHCSCC(state);
-            };
+            });
+
+            PlainComponent.setReducePropsToStateCallback(() => {
+                reducePropsToStateCount++;
+            });
 
             ReactDOM.render(
                 <Helmet
@@ -1221,8 +1216,6 @@ describe("Helmet", () => {
             setTimeout(() => {
                 expect(reducePropsToStateCount).to.equal(1);
                 expect(handleClientStateChangeCount).to.equal(1);
-                PlainComponent.reducePropsToStateCallback = oldRPSC;
-                PlainComponent.handleClientStateChangeCallback = oldHCSCC;
                 done();
             }, 1000);
         });


### PR DESCRIPTION
for critical events like changes in the DOM, or Helmet mounting/updating/unmounting.  Closes #68 