### PR TITLE
Itemprop meta property is added to the list of constants

### DIFF
--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -18,5 +18,6 @@ export const TAG_PROPERTIES = {
 
 export const REACT_TAG_MAP = {
     "charset": "charSet",
-    "http-equiv": "httpEquiv"
+    "http-equiv": "httpEquiv",
+    "itemprop": "itemProp"
 };

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -264,7 +264,8 @@ describe("Helmet", () => {
                             {"charset": "utf-8"},
                             {"name": "description", "content": "Test description"},
                             {"http-equiv": "content-type", "content": "text/html"},
-                            {"property": "og:type", "content": "article"}
+                            {"property": "og:type", "content": "article"},
+                            {"name": "genre", "content": "News", "itemprop": "genre"}
                         ]}
                     />,
                     container


### PR DESCRIPTION
It will allow itemprop property to be generated along with the other properties within meta tags.
Here is an example of how itemprop is used: http://www.w3.org/wiki/WebSchemas/Sports/samples/article-champLeague