### PR TITLE
(fix) provide fallback object istead of `undefined` rewind() result

### DIFF
--- a/src/Helmet.jsx
+++ b/src/Helmet.jsx
@@ -208,6 +208,19 @@ const generateTagsAsReactComponent = (type, tags) => {
     /* eslint-enable react/display-name */
 };
 
+const getMethodsForTag = (type, tags) => ({
+    toComponent: (type === TAG_NAMES.TITLE) ? () => generateTitleAsReactComponent(type, tags) : () => generateTagsAsReactComponent(type, tags),
+    toString: (type === TAG_NAMES.TITLE) ? () => generateTitleAsString(type, tags) : () => generateTagsAsString(type, tags)
+});
+
+const mapStateOnServer = ({title, baseTag, metaTags, linkTags, scriptTags}) => ({
+    title: getMethodsForTag(TAG_NAMES.TITLE, title),
+    base: getMethodsForTag(TAG_NAMES.BASE, baseTag),
+    meta: getMethodsForTag(TAG_NAMES.META, metaTags),
+    link: getMethodsForTag(TAG_NAMES.LINK, linkTags),
+    script: getMethodsForTag(TAG_NAMES.SCRIPT, scriptTags)
+});
+
 const Helmet = (Component) => {
     /* eslint-disable react/no-multi-comp */
     class HelmetWrapper extends React.Component {
@@ -235,7 +248,21 @@ const Helmet = (Component) => {
         }
 
         static peek = Component.peek
-        static rewind = Component.rewind
+        static rewind = () => {
+            let mappedState = Component.rewind();
+            if (!mappedState) {
+                // provide fallback if mappedState is undefined
+                mappedState = mapStateOnServer({
+                    title: "",
+                    baseTag: "",
+                    metaTags: "",
+                    linkTags: "",
+                    scriptTags: ""
+                });
+            }
+
+            return mappedState;
+        }
 
         static set canUseDOM(canUseDOM) {
             Component.canUseDOM = canUseDOM;
@@ -270,19 +297,6 @@ const handleClientStateChange = (newState) => {
 
     onChangeClientState(newState);
 };
-
-const getMethodsForTag = (type, tags) => ({
-    toComponent: (type === TAG_NAMES.TITLE) ? () => generateTitleAsReactComponent(type, tags) : () => generateTagsAsReactComponent(type, tags),
-    toString: (type === TAG_NAMES.TITLE) ? () => generateTitleAsString(type, tags) : () => generateTagsAsString(type, tags)
-});
-
-const mapStateOnServer = ({title, baseTag, metaTags, linkTags, scriptTags}) => ({
-    title: getMethodsForTag(TAG_NAMES.TITLE, title),
-    base: getMethodsForTag(TAG_NAMES.BASE, baseTag),
-    meta: getMethodsForTag(TAG_NAMES.META, metaTags),
-    link: getMethodsForTag(TAG_NAMES.LINK, linkTags),
-    script: getMethodsForTag(TAG_NAMES.SCRIPT, scriptTags)
-});
 
 const SideEffect = withSideEffect(
     reducePropsToState,

--- a/src/test/HelmetTest.jsx
+++ b/src/test/HelmetTest.jsx
@@ -1167,6 +1167,23 @@ describe("Helmet", () => {
                 .that.equals(stringifiedChineseTitle);
         });
 
+        it("rewind() provides a fallback object for empty Helmet state", () => {
+            ReactDOM.render(
+                <div />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head).is.not.an("undefined");
+            expect(head).to.exist;
+            expect(head.base).to.exist;
+            expect(head.title).to.exist;
+            expect(head.meta).to.exist;
+            expect(head.link).to.exist;
+            expect(head.script).to.exist;
+        });
+
         after(() => {
             Helmet.canUseDOM = true;
         });


### PR DESCRIPTION
This PR solves issue https://github.com/nfl/react-helmet/issues/88. 

- provide fallback for `rewind()` result. Otherwise it returns `undefined` when no `<Helmet />` call were made during render cycle
- `mapStateOnServer()`, `getMethodsForTag()` moved above `HelmetWrapper` to make them available for usage in the class