### PR TITLE
Add comment for Component.peak

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -270,7 +270,11 @@ const Helmet = (Component) => {
         shouldComponentUpdate(nextProps) {
             return !deepEqual(this.props, nextProps);
         }
-
+        
+        // Component.peak comes from react-side-effect:
+        // For testing, you may use a static peek() method available on the returned component.
+        // It lets you get the current state without resetting the mounted instance stack.
+        // Don’t use it for anything other than testing.
         static peek = Component.peek
         static rewind = () => {
             let mappedState = Component.rewind();


### PR DESCRIPTION
I was looking through the source, and saw `Component.peak()`, but I didn't know what it was for. Then I searched the issues and found #61, which explains that it comes from `react-side-effect`. I figure adding a comment explaining its purpose wouldn't hurt.

I'm not sure if you prefer more verbose comments or shorter ones. In this case I just copied what it says in the react-side-effect docs. I could move this to the README instead, or remove the extra lines and keep `Component.peak comes from react-side-effect`.
