### PR TITLE
Add defaultTitle as fallback when title is not defined

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -42,7 +42,9 @@ const getTitleFromPropsList = (propsList) => {
         return innermostTemplate.replace(/\%s/g, innermostTitle);
     }
 
-    return innermostTitle || "";
+    const innermostDefaultTitle = getInnermostProperty(propsList, "defaultTitle");
+
+    return innermostTitle || innermostDefaultTitle || "";
 };
 
 const getOnChangeClientState = (propsList) => {
@@ -336,6 +338,7 @@ const Helmet = (Component) => {
     class HelmetWrapper extends React.Component {
         /**
          * @param {String} title: "Title"
+         * @param {String} defaultTitle: "Default Title"
          * @param {Function} onChangeClientState: "(newState) => console.log(newState)"
          * @param {String} titleTemplate: "MySite.com - %s"
          * @param {Object} base: {"target": "_blank", "href": "http://mysite.com/"}
@@ -346,6 +349,7 @@ const Helmet = (Component) => {
          */
         static propTypes = {
             title: React.PropTypes.string,
+            defaultTitle: React.PropTypes.string,
             onChangeClientState: React.PropTypes.func,
             titleTemplate: React.PropTypes.string,
             base: React.PropTypes.object,

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -24,7 +24,8 @@ describe("Helmet", () => {
         describe("title", () => {
             it("can update page title", () => {
                 ReactDOM.render(
-                    <Helmet title={"Test Title"} />,
+                    <Helmet title={"Test Title"}
+                            defaultTitle={"Fallback"} />,
                     container
                 );
 
@@ -68,10 +69,24 @@ describe("Helmet", () => {
                 expect(document.title).to.equal("Main Title");
             });
 
+            it("will use defaultTitle if no title is defined", () => {
+                ReactDOM.render(
+                    <Helmet
+                        title={""}
+                        defaultTitle={"Fallback"}
+                        titleTemplate={"This is a %s of the titleTemplate feature"}
+                    />,
+                    container
+                );
+
+                expect(document.title).to.equal("Fallback");
+            });
+
             it("will use a titleTemplate if defined", () => {
                 ReactDOM.render(
                     <Helmet
                         title={"Test"}
+                        defaultTitle={"Fallback"}
                         titleTemplate={"This is a %s of the titleTemplate feature"}
                     />,
                     container


### PR DESCRIPTION
Adds a defaultTitle option to be used as fallback when a title is not defined.

```js
<Helmet defaultTitle="Aviato" titleTemplate="%s | Aviato"  />
```
yields

```html
<title>Aviato</title>
```

and,

```js
<Helmet Title="Contact" />
```

when composed as a child, yields

```html
<title>Contact | Aviato</title>
```

Fixes #109.

Let me know if this is something you'd consider merging, and I'll sign the CLA.

:beer: 