### PR TITLE
Do not clear html attributes

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -163,20 +163,31 @@ const updateTitle = title => {
 
 const updateHtmlAttributes = (attributes) => {
     const htmlTag = document.getElementsByTagName("html")[0];
-
-    const oldAttributeCount = htmlTag.attributes.length;
-    if (oldAttributeCount) {
-        for (let i = oldAttributeCount - 1; i >= 0; i--) {
-            htmlTag.removeAttribute(htmlTag.attributes[i].name);
-        }
-    }
-
+    const helmetAttr = htmlTag.getAttribute(HELMET_ATTRIBUTE);
+    const helmetAttributes = helmetAttr ? helmetAttr.split(",") : [];
+    const attributesToRemove = [].concat(helmetAttributes);
     const keys = Object.keys(attributes);
+
     for (let i = 0; i < keys.length; i++) {
         const attribute = keys[i];
         const value = typeof attributes[attribute] === "undefined" ? "" : attributes[attribute];
         htmlTag.setAttribute(attribute, value);
+
+        if (helmetAttributes.indexOf(attribute) === -1) {
+            helmetAttributes.push(attribute);
+        }
+
+        const indexToSave = attributesToRemove.indexOf(attribute);
+        if (indexToSave !== -1) {
+            attributesToRemove.splice(indexToSave, 1);
+        }
     }
+
+    for (let i = attributesToRemove.length - 1; i >= 0; i--) {
+        htmlTag.removeAttribute(attributesToRemove[i]);
+    }
+
+    htmlTag.setAttribute(HELMET_ATTRIBUTE, helmetAttributes.join(","));
 };
 
 const updateTags = (type, tags) => {

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -163,14 +163,14 @@ const updateTitle = title => {
 
 const updateHtmlAttributes = (attributes) => {
     const htmlTag = document.getElementsByTagName("html")[0];
-    const helmetAttr = htmlTag.getAttribute(HELMET_ATTRIBUTE);
-    const helmetAttributes = helmetAttr ? helmetAttr.split(",") : [];
+    const helmetAttributeString = htmlTag.getAttribute(HELMET_ATTRIBUTE);
+    const helmetAttributes = helmetAttributeString ? helmetAttributeString.split(",") : [];
     const attributesToRemove = [].concat(helmetAttributes);
-    const keys = Object.keys(attributes);
+    const attributeKeys = Object.keys(attributes);
 
-    for (let i = 0; i < keys.length; i++) {
-        const attribute = keys[i];
-        const value = typeof attributes[attribute] === "undefined" ? "" : attributes[attribute];
+    for (let i = 0; i < attributeKeys.length; i++) {
+        const attribute = attributeKeys[i];
+        const value = attributes[attribute] || "";
         htmlTag.setAttribute(attribute, value);
 
         if (helmetAttributes.indexOf(attribute) === -1) {

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -253,7 +253,7 @@ describe("Helmet", () => {
                     expect(htmlTag.getAttribute("test")).to.equal("helmet-attr");
                 });
 
-                it("can be cleared once specified in helmet", () => {
+                it("can be cleared now that it is managed in helmet", () => {
                     ReactDOM.render(
                         <Helmet />,
                         container

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -209,7 +209,7 @@ describe("Helmet", () => {
                 expect(htmlTag.getAttribute("amp")).to.equal("");
             });
 
-            it("clears attributes if none are specified", () => {
+            it("clears attributes that are handled within helmet", () => {
                 ReactDOM.render(
                     <Helmet />,
                     container
@@ -217,7 +217,20 @@ describe("Helmet", () => {
 
                 const htmlTag = document.getElementsByTagName("html")[0];
 
-                expect(htmlTag.attributes.length).to.equal(0);
+                expect(htmlTag.getAttribute("lang")).to.be.null;
+                expect(htmlTag.getAttribute("amp")).to.be.null;
+            });
+
+            it("will not clear attributes handled outside of helmet", () => {
+                const htmlTag = document.getElementsByTagName("html")[0];
+                htmlTag.setAttribute("test", "test");
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                expect(htmlTag.getAttribute("test")).to.equal("test");
             });
         });
 

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -228,12 +228,12 @@ describe("Helmet", () => {
                 });
 
                 it("will not be cleared", () => {
-                    const htmlTag = document.getElementsByTagName("html")[0];
-
                     ReactDOM.render(
                         <Helmet />,
                         container
                     );
+
+                    const htmlTag = document.getElementsByTagName("html")[0];
 
                     expect(htmlTag.getAttribute("test")).to.equal("test");
                 });

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -221,16 +221,48 @@ describe("Helmet", () => {
                 expect(htmlTag.getAttribute("amp")).to.be.null;
             });
 
-            it("will not clear attributes handled outside of helmet", () => {
-                const htmlTag = document.getElementsByTagName("html")[0];
-                htmlTag.setAttribute("test", "test");
+            context("initialized outside of helmet", () => {
+                before(() => {
+                    const htmlTag = document.getElementsByTagName("html")[0];
+                    htmlTag.setAttribute("test", "test");
+                });
 
-                ReactDOM.render(
-                    <Helmet />,
-                    container
-                );
+                it("will not be cleared", () => {
+                    const htmlTag = document.getElementsByTagName("html")[0];
 
-                expect(htmlTag.getAttribute("test")).to.equal("test");
+                    ReactDOM.render(
+                        <Helmet />,
+                        container
+                    );
+
+                    expect(htmlTag.getAttribute("test")).to.equal("test");
+                });
+
+                it("will be overwritten if specified in helmet", () => {
+                    ReactDOM.render(
+                        <Helmet
+                            htmlAttributes={{
+                                "test": "helmet-attr"
+                            }}
+                        />,
+                        container
+                    );
+
+                    const htmlTag = document.getElementsByTagName("html")[0];
+
+                    expect(htmlTag.getAttribute("test")).to.equal("helmet-attr");
+                });
+
+                it("can be cleared once specified in helmet", () => {
+                    ReactDOM.render(
+                        <Helmet />,
+                        container
+                    );
+
+                    const htmlTag = document.getElementsByTagName("html")[0];
+
+                    expect(htmlTag.getAttribute("test")).to.equal(null);
+                });
             });
         });
 


### PR DESCRIPTION
Addresses issue #121 

Any html attributes included independently of Helmet will be left alone on render. Any attributes added or modified by Helmet will be erased on future renders if they are left out of the props passed to Helmet.