### PR TITLE
Clearing cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Bugfixes:
 Features:
 
   - innerHTML for scripts.  Originally added to support the use of JSON-LD (https://developers.google.com/schemas/formats/json-ld?hl=en), but this can be used for any inline scripts you would like in your document head.
-  - New htmlAttributes prop which allows users to add attributes to their html tag.  For now, "lang" and "amp" are supported.
+  - New htmlAttributes prop which allows users to add attributes to their html tag.
   - New defaultTitle prop which allows users to have a fallback title in the scenario where a Helmet wants to define a titleTemplate for it's nested routes, but not for itself (for example, at the root component level).  See README for use cases.
 
 Bugfixes:

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -187,7 +187,11 @@ const updateHtmlAttributes = (attributes) => {
         htmlTag.removeAttribute(attributesToRemove[i]);
     }
 
-    htmlTag.setAttribute(HELMET_ATTRIBUTE, helmetAttributes.join(","));
+    if (helmetAttributes.length === attributesToRemove.length) {
+        htmlTag.removeAttribute(HELMET_ATTRIBUTE);
+    } else {
+        htmlTag.setAttribute(HELMET_ATTRIBUTE, helmetAttributes.join(","));
+    }
 };
 
 const updateTags = (type, tags) => {

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -211,6 +211,16 @@ describe("Helmet", () => {
 
             it("clears attributes that are handled within helmet", () => {
                 ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "lang": "en",
+                            "amp": undefined
+                        }}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
                     <Helmet />,
                     container
                 );
@@ -351,6 +361,13 @@ describe("Helmet", () => {
 
             it("will clear the base tag if one is not specified", () => {
                 ReactDOM.render(
+                    <Helmet
+                        base={{"href": "http://mysite.com/"}}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
                     <Helmet />,
                     container
                 );
@@ -433,6 +450,13 @@ describe("Helmet", () => {
             });
 
             it("will clear all meta tags if none are specified", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={[{"name": "description", "content": "Test description"}]}
+                    />,
+                    container
+                );
+
                 ReactDOM.render(
                     <Helmet />,
                     container
@@ -655,6 +679,15 @@ describe("Helmet", () => {
             });
 
             it("will clear all link tags if none are specified", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"href": "http://localhost/helmet", "rel": "canonical"}
+                        ]}
+                    />,
+                    container
+                );
+
                 ReactDOM.render(
                     <Helmet />,
                     container
@@ -974,6 +1007,15 @@ describe("Helmet", () => {
             });
 
             it("will clear all scripts tags if none are specified", () => {
+                ReactDOM.render(
+                    <Helmet
+                        script={[
+                            {"src": "http://localhost/test.js", "type": "text/javascript"}
+                        ]}
+                    />,
+                    container
+                );
+
                 ReactDOM.render(
                     <Helmet />,
                     container

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -170,6 +170,7 @@ describe("Helmet", () => {
                 const htmlTag = document.getElementsByTagName("html")[0];
 
                 expect(htmlTag.getAttribute("lang")).to.equal("en");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("lang");
             });
 
             it("set attributes based on the deepest nested component", () => {
@@ -192,6 +193,7 @@ describe("Helmet", () => {
                 const htmlTag = document.getElementsByTagName("html")[0];
 
                 expect(htmlTag.getAttribute("lang")).to.equal("ja");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("lang");
             });
 
             it("handle valueless attributes", () =>{
@@ -207,9 +209,10 @@ describe("Helmet", () => {
                 const htmlTag = document.getElementsByTagName("html")[0];
 
                 expect(htmlTag.getAttribute("amp")).to.equal("");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("amp");
             });
 
-            it("clears attributes that are handled within helmet", () => {
+            it("clears html attributes that are handled within helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         htmlAttributes={{
@@ -229,6 +232,7 @@ describe("Helmet", () => {
 
                 expect(htmlTag.getAttribute("lang")).to.be.null;
                 expect(htmlTag.getAttribute("amp")).to.be.null;
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
             });
 
             context("initialized outside of helmet", () => {
@@ -246,6 +250,7 @@ describe("Helmet", () => {
                     const htmlTag = document.getElementsByTagName("html")[0];
 
                     expect(htmlTag.getAttribute("test")).to.equal("test");
+                    expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
                 });
 
                 it("will be overwritten if specified in helmet", () => {
@@ -261,9 +266,19 @@ describe("Helmet", () => {
                     const htmlTag = document.getElementsByTagName("html")[0];
 
                     expect(htmlTag.getAttribute("test")).to.equal("helmet-attr");
+                    expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("test");
                 });
 
-                it("can be cleared now that it is managed in helmet", () => {
+                it("can be cleared once it is managed in helmet", () => {
+                    ReactDOM.render(
+                        <Helmet
+                            htmlAttributes={{
+                                "test": "helmet-attr"
+                            }}
+                        />,
+                        container
+                    );
+
                     ReactDOM.render(
                         <Helmet />,
                         container
@@ -272,6 +287,7 @@ describe("Helmet", () => {
                     const htmlTag = document.getElementsByTagName("html")[0];
 
                     expect(htmlTag.getAttribute("test")).to.equal(null);
+                    expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
                 });
             });
         });


### PR DESCRIPTION
- Unit tests (for all types) updated to account for the Helmet being unmounted after each test case, therefore the clear cases need to render something in the Helmet, to have something to clear.

- htmlAttribute update logic cleans up data-react-helmet attribute in html tag when all html attributes are cleared from Helmet.