### PR TITLE
Closes #132: Explicity render PlainComponent to noscript tag

### DIFF
--- a/src/PlainComponent.js
+++ b/src/PlainComponent.js
@@ -2,6 +2,6 @@ import React from "react";
 
 export default class PlainComponent extends React.Component {
     render() {
-        return null;
+        return <noscript />;
     }
 }


### PR DESCRIPTION
This PR fixes issue #132 introduced by react >= 15 and its new data-reactid implementation. 
It consists in explicitly rendering a `<noscript>` tag, as suggested in the issue, and agreed on by @cwelch5 .
Thanks for bringing React Helmet to the Open Source Community.
Please let me know if this PR could be enhanced in any way. 