### PR TITLE
fix(react-helmet): Avoid writing undefined attributes to DOM

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -261,6 +261,11 @@ const generateTagsAsString = (type, tags) => {
                 if (attribute === "innerHTML") {
                     return "";
                 }
+
+                if (typeof tag[attribute] === "undefined") {
+                    return attribute;
+                }
+
                 const encodedValue = encodeSpecialCharacters(tag[attribute]);
                 return `${attribute}="${encodedValue}"`;
             })

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -207,7 +207,8 @@ const updateTags = (type, tags) => {
                     if (attribute === "innerHTML") {
                         newElement.innerHTML = tag.innerHTML;
                     } else {
-                        newElement.setAttribute(attribute, tag[attribute]);
+                        const value = (typeof tag[attribute] === "undefined") ? "" : tag[attribute];
+                        newElement.setAttribute(attribute, value);
                     }
                 }
             }
@@ -269,7 +270,7 @@ const generateTagsAsString = (type, tags) => {
                 const encodedValue = encodeSpecialCharacters(tag[attribute]);
                 return `${attribute}="${encodedValue}"`;
             })
-            .join(" ");
+            .join(" ").trim();
 
         const innerHTML = tag.innerHTML || "";
 

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -1041,6 +1041,28 @@ describe("Helmet", () => {
                 expect(secondTag.getAttribute("type")).to.equal("text/javascript");
                 expect(secondTag.outerHTML).to.equal(`<script src="http://localhost/test2.js" type="text/javascript" ${HELMET_ATTRIBUTE}="true"></script>`);
             });
+
+
+            it("sets undefined attribute values to empty strings", () => {
+                ReactDOM.render(
+                    <Helmet
+                        script={[
+                            {
+                                src: "foo.js",
+                                async: undefined
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const existingTag = headElement.querySelector(`script[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTag).to.not.equal(undefined);
+                expect(existingTag.outerHTML)
+                    .to.be.a("string")
+                    .that.equals(`<script src="foo.js" async="" ${HELMET_ATTRIBUTE}="true"></script>`);
+            });
         });
     });
 
@@ -1471,6 +1493,26 @@ describe("Helmet", () => {
             expect(head.script).to.exist;
         });
 
+        it("does not render undefined attribute values", () => {
+            ReactDOM.render(
+                <Helmet
+                    script={[
+                        {
+                            src: "foo.js",
+                            async: undefined
+                        }
+                    ]}
+                />,
+                container
+            );
+
+            const {script} = Helmet.rewind();
+            const stringifiedScriptTag = script.toString();
+
+            expect(stringifiedScriptTag)
+                .to.be.a("string")
+                .that.equals(`<script ${HELMET_ATTRIBUTE}="true" src="foo.js" async></script>`);
+        });
         after(() => {
             Helmet.canUseDOM = true;
         });


### PR DESCRIPTION
Fixes an issue where Helmet was writing undefined attributes to DOM. E.g. given this Helmet call:

```js
<Helmet script={[
  {
    "src": "foo.js",
    "async": undefined
  }
]} />
```

it converts this:

```html
<script src="foo.js" async="undefined"></script>
```

to this:

```html
<script src="foo.js" async></script>
```