### PR TITLE
Render children components if passed to Helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "main": "./lib/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [

--- a/src/PlainComponent.js
+++ b/src/PlainComponent.js
@@ -1,7 +1,14 @@
 import React from "react";
 
 export default class PlainComponent extends React.Component {
+    static propTypes = {
+        children: React.PropTypes.node
+    }
+
     render() {
+        if (this.props.children) {
+            return React.Children.only(this.props.children);
+        }
         return null;
     }
 }

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -127,6 +127,47 @@ describe("Helmet", () => {
                 expect(document.title).to.equal("A Second Test using nested titleTemplate attributes");
             });
 
+            it("will mount children if they are given to Helmet", () => {
+                ReactDOM.render(
+                    <Helmet title="Test">
+                        <div id="element">Hi</div>
+                    </Helmet>,
+                    container
+                );
+                expect(document.title).to.equal('Test');
+                const element = container.childNodes[0];
+                expect(element).to.exist;
+                expect(element.textContent).to.equal('Hi');
+            });
+
+            it("throws if Helmet has multiple children", () => {
+                let exception;
+                try {
+                    ReactDOM.render(
+                        <Helmet title="Test">
+                            <div>Hi</div>
+                            <div>Hi again</div>
+                        </Helmet>,
+                        container
+                    );
+                } catch (e) {
+                    exception = e;
+                }
+                expect(exception).to.exist;
+            });
+
+            it("will mount children if they are given to Helmet", () => {
+                ReactDOM.render(
+                    <Helmet title="Test">
+                        <div id="element">
+                            <Helmet title="Inner Title" />
+                        </div>
+                    </Helmet>,
+                    container
+                );
+                expect(document.title).to.equal('Inner Title');
+            });
+
             it("will merge deepest component title with nearest upstream titleTemplate", () => {
                 ReactDOM.render(
                     <div>
@@ -1875,21 +1916,6 @@ describe("Helmet", () => {
             expect(removedTags.metaTags).to.have.deep.property("[0]");
             expect(removedTags.metaTags[0].outerHTML).to.equal(`<meta name="description" content="Test description" data-react-helmet="true">`);
             expect(removedTags).to.not.have.property("linkTags");
-        });
-
-        it("can not nest Helmets", () => {
-            ReactDOM.render(
-                <Helmet
-                    title={"Test Title"}
-                >
-                    <Helmet
-                        title={"Title you'll never see"}
-                    />
-                </Helmet>,
-                container
-            );
-
-            expect(document.title).to.equal("Test Title");
         });
 
         it("will recognize valid tags regardless of attribute ordering", () => {


### PR DESCRIPTION
This change allows passing children elements to `<Helmet />`, like `react-document-title` does. See [here](https://github.com/gaearon/react-document-title/blob/master/index.js#L25). This makes it easier for developers to migrate from `react-document-title`, where it's common to wrap a component in the `<DocumentTitle>` component. See all examples in the [README](https://github.com/gaearon/react-document-title#example).

Now a component can be structured like this:

```js
render() {
  return (
    <Helmet title="Anything">
      <div>Child element</div>
    </Helmet>
  )
}
```