### PR TITLE
handle null values for tags (and fix eslinting error)

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -21,7 +21,7 @@ const encodeSpecialCharacters = (str) => {
 };
 
 const getInnermostProperty = (propsList, property) => {
-    for(let i = propsList.length - 1; i >= 0; i--) {
+    for (let i = propsList.length - 1; i >= 0; i--) {
         const props = propsList[i];
 
         if (props[property]) {
@@ -110,7 +110,7 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                     }
                 }
 
-                if (!primaryAttributeKey) {
+                if (!primaryAttributeKey || !tag[primaryAttributeKey]) {
                     return false;
                 }
 

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -984,6 +984,33 @@ describe("Helmet", () => {
                 expect(secondTag.getAttribute("href")).to.equal("http://localhost/helmet/innercomponent");
                 expect(secondTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/innercomponent" ${HELMET_ATTRIBUTE}="true">`);
             });
+
+            it("will remove tags with null values", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"rel": "icon", "sizes": "192x192", "href": null},
+                            {"rel": "canonical", "href": "http://localhost/helmet/component"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.be.equal(1);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("rel")).to.equal("canonical");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/helmet/component");
+                expect(firstTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/component" ${HELMET_ATTRIBUTE}="true">`);
+            });
         });
 
         describe("script tags", () => {


### PR DESCRIPTION
If the primaryAttributeKey's value is null, then we ignore that entire tag. This is mostly useful for programmatic definitions of tag values where the data store may not be fully defined. This resolves #162.

For instance (and exemplified in test code), if an icon is being described, but `null` is provided in the `href`, the tag will not be added.

I also fixed an eslint error on `src/Helmet.js` ln 24.
