### PR TITLE
Add itemProp attributes for meta tag, titleAttributes for title

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -21,7 +21,7 @@ const encodeSpecialCharacters = (str) => {
 };
 
 const getInnermostProperty = (propsList, property) => {
-    for(let i = propsList.length - 1; i >= 0; i--) {
+    for (let i = propsList.length - 1; i >= 0; i--) {
         const props = propsList[i];
 
         if (props[property]) {
@@ -42,6 +42,11 @@ const getTitleFromPropsList = (propsList) => {
     const innermostDefaultTitle = getInnermostProperty(propsList, "defaultTitle");
 
     return innermostTitle || innermostDefaultTitle || "";
+};
+
+const getTitlePropsFromPropsList = (propsList) => {
+    const innermostTitleProps = getInnermostProperty(propsList, "titleProps");
+    return innermostTitleProps || [];
 };
 
 const getOnChangeClientState = (propsList) => {
@@ -105,7 +110,7 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                         primaryAttributeKey = lowerCaseAttributeKey;
                     }
                     // Special case for innerHTML which doesn't work lowercased
-                    if (primaryAttributes.indexOf(attributeKey) !== -1 && (attributeKey === TAG_PROPERTIES.INNER_HTML || attributeKey === TAG_PROPERTIES.CSS_TEXT)) {
+                    if (primaryAttributes.indexOf(attributeKey) !== -1 && (attributeKey === TAG_PROPERTIES.INNER_HTML || attributeKey === TAG_PROPERTIES.CSS_TEXT || attributeKey === TAG_PROPERTIES.ITEM_PROP)) {
                         primaryAttributeKey = attributeKey;
                     }
                 }
@@ -154,8 +159,17 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
     return tagList;
 };
 
-const updateTitle = title => {
+const updateTitle = (title, titleProps) => {
     document.title = title || document.title;
+    const htmlTag = document.getElementsByTagName("title")[0];
+    titleProps.forEach((attributes) => {
+        const attributeKeys = Object.keys(attributes);
+        for (let i = 0; i < attributeKeys.length; i++) {
+            const attribute = attributeKeys[i];
+            const value = attributes[attribute] || "";
+            htmlTag.setAttribute(attribute, value);
+        }
+    });
 };
 
 const updateHtmlAttributes = (attributes) => {
@@ -256,8 +270,20 @@ const generateHtmlAttributesAsString = (attributes) => {
     return attributeString.trim();
 };
 
-const generateTitleAsString = (type, title) => {
-    const stringifiedMarkup = `<${type} ${HELMET_ATTRIBUTE}="true">${encodeSpecialCharacters(title)}</${type}>`;
+const generateTitleAsString = (type, title, titleProps) => {
+    let attributeString = "";
+    titleProps.forEach((attributes) => {
+        const attributeKeys = Object.keys(attributes);
+        for (let i = 0; i < attributeKeys.length; i++) {
+            const attribute = attributeKeys[i];
+            const attr = typeof attributes[attribute] !== "undefined" ? `${attribute.toLowerCase()}="${attributes[attribute]}"` : `${attribute.toLowerCase()}`;
+            attributeString += `${attr} `;
+        }
+    });
+
+    const stringifiedMarkup = attributeString
+                                ? `<${type} ${HELMET_ATTRIBUTE}="true" ${attributeString.trim()}>${encodeSpecialCharacters(title)}</${type}>`
+                                : `<${type} ${HELMET_ATTRIBUTE}="true">${encodeSpecialCharacters(title)}</${type}>`;
 
     return stringifiedMarkup;
 };
@@ -284,15 +310,22 @@ const generateTagsAsString = (type, tags) => {
     return stringifiedMarkup;
 };
 
-const generateTitleAsReactComponent = (type, title) => {
+const generateTitleAsReactComponent = (type, title, titleProps) => {
     // assigning into an array to define toString function on it
+    const props = {
+        key: title,
+        [HELMET_ATTRIBUTE]: true
+    };
+    titleProps.forEach((tag) => {
+        Object.keys(tag).forEach((attribute) => {
+            props[attribute] = tag[attribute];
+        });
+    });
+
     const component = [
         React.createElement(
             TAG_NAMES.TITLE,
-            {
-                key: title,
-                [HELMET_ATTRIBUTE]: true
-            },
+            props,
             title
         )
     ];
@@ -330,8 +363,8 @@ const getMethodsForTag = (type, tags) => {
     switch (type) {
         case TAG_NAMES.TITLE:
             return {
-                toComponent: () => generateTitleAsReactComponent(type, tags),
-                toString: () => generateTitleAsString(type, tags)
+                toComponent: () => generateTitleAsReactComponent(type, tags.title, tags.titleProps),
+                toString: () => generateTitleAsString(type, tags.title, tags.titleProps)
             };
         case TAG_NAMES.HTML:
             return {
@@ -346,9 +379,9 @@ const getMethodsForTag = (type, tags) => {
     }
 };
 
-const mapStateOnServer = ({htmlAttributes, title, baseTag, metaTags, linkTags, scriptTags, styleTags}) => ({
+const mapStateOnServer = ({htmlAttributes, title, titleProps, baseTag, metaTags, linkTags, scriptTags, styleTags}) => ({
     htmlAttributes: getMethodsForTag(TAG_NAMES.HTML, htmlAttributes),
-    title: getMethodsForTag(TAG_NAMES.TITLE, title),
+    title: getMethodsForTag(TAG_NAMES.TITLE, {title, titleProps}),
     base: getMethodsForTag(TAG_NAMES.BASE, baseTag),
     meta: getMethodsForTag(TAG_NAMES.META, metaTags),
     link: getMethodsForTag(TAG_NAMES.LINK, linkTags),
@@ -364,6 +397,7 @@ const Helmet = (Component) => {
          * @param {String} title: "Title"
          * @param {String} defaultTitle: "Default Title"
          * @param {String} titleTemplate: "MySite.com - %s"
+         * @param {Array} titleProps: [{"itemProp": "name"}]
          * @param {Object} base: {"target": "_blank", "href": "http://mysite.com/"}
          * @param {Array} meta: [{"name": "description", "content": "Test description"}]
          * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example"}]
@@ -376,6 +410,7 @@ const Helmet = (Component) => {
             title: React.PropTypes.string,
             defaultTitle: React.PropTypes.string,
             titleTemplate: React.PropTypes.string,
+            titleProps: React.PropTypes.arrayOf(React.PropTypes.object),
             base: React.PropTypes.object,
             meta: React.PropTypes.arrayOf(React.PropTypes.object),
             link: React.PropTypes.arrayOf(React.PropTypes.object),
@@ -401,6 +436,7 @@ const Helmet = (Component) => {
                 mappedState = mapStateOnServer({
                     htmlAttributes: [],
                     title: "",
+                    titleProps: [],
                     baseTag: [],
                     metaTags: [],
                     linkTags: [],
@@ -428,8 +464,9 @@ const Helmet = (Component) => {
 const reducePropsToState = (propsList) => ({
     htmlAttributes: getHtmlAttributesFromPropsList(propsList),
     title: getTitleFromPropsList(propsList),
+    titleProps: getTitlePropsFromPropsList(propsList),
     baseTag: getBaseTagFromPropsList([TAG_PROPERTIES.HREF], propsList),
-    metaTags: getTagsFromPropsList(TAG_NAMES.META, [TAG_PROPERTIES.NAME, TAG_PROPERTIES.CHARSET, TAG_PROPERTIES.HTTPEQUIV, TAG_PROPERTIES.PROPERTY], propsList),
+    metaTags: getTagsFromPropsList(TAG_NAMES.META, [TAG_PROPERTIES.NAME, TAG_PROPERTIES.CHARSET, TAG_PROPERTIES.HTTPEQUIV, TAG_PROPERTIES.PROPERTY, TAG_PROPERTIES.ITEM_PROP], propsList),
     linkTags: getTagsFromPropsList(TAG_NAMES.LINK, [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF], propsList),
     scriptTags: getTagsFromPropsList(TAG_NAMES.SCRIPT, [TAG_PROPERTIES.SRC, TAG_PROPERTIES.INNER_HTML], propsList),
     styleTags: getTagsFromPropsList(TAG_NAMES.STYLE, [TAG_PROPERTIES.CSS_TEXT], propsList),
@@ -440,6 +477,7 @@ const handleClientStateChange = (newState) => {
     const {
         htmlAttributes,
         title,
+        titleProps,
         baseTag,
         metaTags,
         linkTags,
@@ -450,7 +488,7 @@ const handleClientStateChange = (newState) => {
 
     updateHtmlAttributes(htmlAttributes);
 
-    updateTitle(title);
+    updateTitle(title, titleProps);
 
     const tagUpdates = {
         baseTag: updateTags(TAG_NAMES.BASE, baseTag),

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -159,17 +159,15 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
     return tagList;
 };
 
-const updateTitle = (title, titleProps) => {
+const updateTitle = (title, attributes) => {
     document.title = title || document.title;
     const htmlTag = document.getElementsByTagName("title")[0];
-    titleProps.forEach((attributes) => {
-        const attributeKeys = Object.keys(attributes);
-        for (let i = 0; i < attributeKeys.length; i++) {
-            const attribute = attributeKeys[i];
-            const value = attributes[attribute] || "";
-            htmlTag.setAttribute(attribute, value);
-        }
-    });
+    const attributeKeys = Object.keys(attributes);
+    for (let i = 0; i < attributeKeys.length; i++) {
+        const attribute = attributeKeys[i];
+        const value = attributes[attribute] || "";
+        htmlTag.setAttribute(attribute, value);
+    }
 };
 
 const updateHtmlAttributes = (attributes) => {
@@ -270,16 +268,14 @@ const generateHtmlAttributesAsString = (attributes) => {
     return attributeString.trim();
 };
 
-const generateTitleAsString = (type, title, titleProps) => {
+const generateTitleAsString = (type, title, attributes) => {
     let attributeString = "";
-    titleProps.forEach((attributes) => {
-        const attributeKeys = Object.keys(attributes);
-        for (let i = 0; i < attributeKeys.length; i++) {
-            const attribute = attributeKeys[i];
-            const attr = typeof attributes[attribute] !== "undefined" ? `${attribute.toLowerCase()}="${attributes[attribute]}"` : `${attribute.toLowerCase()}`;
-            attributeString += `${attr} `;
-        }
-    });
+    const attributeKeys = Object.keys(attributes);
+    for (let i = 0; i < attributeKeys.length; i++) {
+        const attribute = attributeKeys[i];
+        const attr = typeof attributes[attribute] !== "undefined" ? `${attribute.toLowerCase()}="${attributes[attribute]}"` : `${attribute.toLowerCase()}`;
+        attributeString += `${attr} `;
+    }
 
     const stringifiedMarkup = attributeString
                                 ? `<${type} ${HELMET_ATTRIBUTE}="true" ${attributeString.trim()}>${encodeSpecialCharacters(title)}</${type}>`
@@ -320,10 +316,8 @@ const generateTitleAsReactComponent = (type, title, titleProps) => {
         key: title,
         [HELMET_ATTRIBUTE]: true
     };
-    titleProps.forEach((tag) => {
-        Object.keys(tag).forEach((attribute) => {
-            props[attribute] = tag[attribute];
-        });
+    Object.keys(titleProps).forEach((attribute) => {
+        props[attribute] = titleProps[attribute];
     });
 
     const component = [
@@ -401,7 +395,7 @@ const Helmet = (Component) => {
          * @param {String} title: "Title"
          * @param {String} defaultTitle: "Default Title"
          * @param {String} titleTemplate: "MySite.com - %s"
-         * @param {Array} titleProps: [{"itemProp": "name"}]
+         * @param {Object} titleProps: {"itemProp": "name"}
          * @param {Object} base: {"target": "_blank", "href": "http://mysite.com/"}
          * @param {Array} meta: [{"name": "description", "content": "Test description"}]
          * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example"}]
@@ -414,7 +408,7 @@ const Helmet = (Component) => {
             title: React.PropTypes.string,
             defaultTitle: React.PropTypes.string,
             titleTemplate: React.PropTypes.string,
-            titleProps: React.PropTypes.arrayOf(React.PropTypes.object),
+            titleProps: React.PropTypes.object,
             base: React.PropTypes.object,
             meta: React.PropTypes.arrayOf(React.PropTypes.object),
             link: React.PropTypes.arrayOf(React.PropTypes.object),
@@ -440,7 +434,7 @@ const Helmet = (Component) => {
                 mappedState = mapStateOnServer({
                     htmlAttributes: [],
                     title: "",
-                    titleProps: [],
+                    titleProps: {},
                     baseTag: [],
                     metaTags: [],
                     linkTags: [],

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -44,9 +44,9 @@ const getTitleFromPropsList = (propsList) => {
     return innermostTitle || innermostDefaultTitle || "";
 };
 
-const getTitlePropsFromPropsList = (propsList) => {
-    const innermostTitleProps = getInnermostProperty(propsList, "titleProps");
-    return innermostTitleProps || [];
+const getTitleAttributesFromPropsList = (propsList) => {
+    const innermostTitleAttributes = getInnermostProperty(propsList, "titleAttributes");
+    return innermostTitleAttributes || [];
 };
 
 const getOnChangeClientState = (propsList) => {
@@ -310,14 +310,14 @@ const generateTagsAsString = (type, tags) => {
     return stringifiedMarkup;
 };
 
-const generateTitleAsReactComponent = (type, title, titleProps) => {
+const generateTitleAsReactComponent = (type, title, attributes) => {
     // assigning into an array to define toString function on it
     const props = {
         key: title,
         [HELMET_ATTRIBUTE]: true
     };
-    Object.keys(titleProps).forEach((attribute) => {
-        props[attribute] = titleProps[attribute];
+    Object.keys(attributes).forEach((attribute) => {
+        props[attribute] = attributes[attribute];
     });
 
     const component = [
@@ -361,8 +361,8 @@ const getMethodsForTag = (type, tags) => {
     switch (type) {
         case TAG_NAMES.TITLE:
             return {
-                toComponent: () => generateTitleAsReactComponent(type, tags.title, tags.titleProps),
-                toString: () => generateTitleAsString(type, tags.title, tags.titleProps)
+                toComponent: () => generateTitleAsReactComponent(type, tags.title, tags.titleAttributes),
+                toString: () => generateTitleAsString(type, tags.title, tags.titleAttributes)
             };
         case TAG_NAMES.HTML:
             return {
@@ -377,9 +377,9 @@ const getMethodsForTag = (type, tags) => {
     }
 };
 
-const mapStateOnServer = ({htmlAttributes, title, titleProps, baseTag, metaTags, linkTags, scriptTags, styleTags}) => ({
+const mapStateOnServer = ({htmlAttributes, title, titleAttributes, baseTag, metaTags, linkTags, scriptTags, styleTags}) => ({
     htmlAttributes: getMethodsForTag(TAG_NAMES.HTML, htmlAttributes),
-    title: getMethodsForTag(TAG_NAMES.TITLE, {title, titleProps}),
+    title: getMethodsForTag(TAG_NAMES.TITLE, {title, titleAttributes}),
     base: getMethodsForTag(TAG_NAMES.BASE, baseTag),
     meta: getMethodsForTag(TAG_NAMES.META, metaTags),
     link: getMethodsForTag(TAG_NAMES.LINK, linkTags),
@@ -395,7 +395,7 @@ const Helmet = (Component) => {
          * @param {String} title: "Title"
          * @param {String} defaultTitle: "Default Title"
          * @param {String} titleTemplate: "MySite.com - %s"
-         * @param {Object} titleProps: {"itemProp": "name"}
+         * @param {Object} titleAttributes: {"itemProp": "name"}
          * @param {Object} base: {"target": "_blank", "href": "http://mysite.com/"}
          * @param {Array} meta: [{"name": "description", "content": "Test description"}]
          * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example"}]
@@ -408,7 +408,7 @@ const Helmet = (Component) => {
             title: React.PropTypes.string,
             defaultTitle: React.PropTypes.string,
             titleTemplate: React.PropTypes.string,
-            titleProps: React.PropTypes.object,
+            titleAttributes: React.PropTypes.object,
             base: React.PropTypes.object,
             meta: React.PropTypes.arrayOf(React.PropTypes.object),
             link: React.PropTypes.arrayOf(React.PropTypes.object),
@@ -434,7 +434,7 @@ const Helmet = (Component) => {
                 mappedState = mapStateOnServer({
                     htmlAttributes: [],
                     title: "",
-                    titleProps: {},
+                    titleAttributes: {},
                     baseTag: [],
                     metaTags: [],
                     linkTags: [],
@@ -462,7 +462,7 @@ const Helmet = (Component) => {
 const reducePropsToState = (propsList) => ({
     htmlAttributes: getHtmlAttributesFromPropsList(propsList),
     title: getTitleFromPropsList(propsList),
-    titleProps: getTitlePropsFromPropsList(propsList),
+    titleAttributes: getTitleAttributesFromPropsList(propsList),
     baseTag: getBaseTagFromPropsList([TAG_PROPERTIES.HREF], propsList),
     metaTags: getTagsFromPropsList(TAG_NAMES.META, [TAG_PROPERTIES.NAME, TAG_PROPERTIES.CHARSET, TAG_PROPERTIES.HTTPEQUIV, TAG_PROPERTIES.PROPERTY, TAG_PROPERTIES.ITEM_PROP], propsList),
     linkTags: getTagsFromPropsList(TAG_NAMES.LINK, [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF], propsList),
@@ -475,7 +475,7 @@ const handleClientStateChange = (newState) => {
     const {
         htmlAttributes,
         title,
-        titleProps,
+        titleAttributes,
         baseTag,
         metaTags,
         linkTags,
@@ -486,7 +486,7 @@ const handleClientStateChange = (newState) => {
 
     updateHtmlAttributes(htmlAttributes);
 
-    updateTitle(title, titleProps);
+    updateTitle(title, titleAttributes);
 
     const tagUpdates = {
         baseTag: updateTags(TAG_NAMES.BASE, baseTag),

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -298,6 +298,10 @@ const generateTagsAsString = (type, tags) => {
                 }
 
                 const encodedValue = encodeSpecialCharacters(tag[attribute]);
+                // itemProp in react is camelcase, but will generate as lowercase
+                if (attribute === 'itemProp') {
+                    return `${attribute.toLowerCase()}="${encodedValue}"`;
+                }
                 return `${attribute}="${encodedValue}"`;
             })
             .join(" ").trim();

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -17,7 +17,8 @@ export const TAG_PROPERTIES = {
     PROPERTY: "property",
     SRC: "src",
     INNER_HTML: "innerHTML",
-    CSS_TEXT: "cssText"
+    CSS_TEXT: "cssText",
+    ITEM_PROP: "itemProp"
 };
 
 export const REACT_TAG_MAP = {

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -476,7 +476,6 @@ describe("Helmet", () => {
                     return tag.getAttribute("charset") === "utf-8" ||
                         (tag.getAttribute("name") === "description" && tag.getAttribute("content") === "Test description") ||
                         (tag.getAttribute("http-equiv") === "content-type" && tag.getAttribute("content") === "text/html") ||
-                        (tag.getAttribute("property") === "og-type" && tag.getAttribute("content") === "article") ||
                         (tag.getAttribute("itemprop") === "name" && tag.getAttribute("content") === "Test name itemprop");
                 });
 

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -159,7 +159,7 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         title={"Test Title with itemProp"}
-                        titleProps={{itemProp: 'name'}}
+                        titleAttributes={{itemProp: 'name'}}
                         defaultTitle={"Fallback"}
                     />,
                     container
@@ -1328,7 +1328,7 @@ describe("Helmet", () => {
             ReactDOM.render(
                 <Helmet
                     title={"Title with Itemprop"}
-                    titleProps={{itemProp: 'name'}}
+                    titleAttributes={{itemProp: 'name'}}
                 />,
                 container
             );

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -159,7 +159,7 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         title={"Test Title with itemProp"}
-                        titleProps={[{itemProp: 'name'}]}
+                        titleProps={{itemProp: 'name'}}
                         defaultTitle={"Fallback"}
                     />,
                     container
@@ -1328,7 +1328,7 @@ describe("Helmet", () => {
             ReactDOM.render(
                 <Helmet
                     title={"Title with Itemprop"}
-                    titleProps={[{itemProp: 'name'}]}
+                    titleProps={{itemProp: 'name'}}
                 />,
                 container
             );

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -460,7 +460,8 @@ describe("Helmet", () => {
                             {"charset": "utf-8"},
                             {"name": "description", "content": "Test description"},
                             {"http-equiv": "content-type", "content": "text/html"},
-                            {"property": "og:type", "content": "article"}
+                            {"property": "og:type", "content": "article"},
+                            {"itemProp": "name", "content": "Test name itemprop"}
                         ]}
                     />,
                     container
@@ -474,10 +475,12 @@ describe("Helmet", () => {
                 const filteredTags = [].slice.call(existingTags).filter((tag) => {
                     return tag.getAttribute("charset") === "utf-8" ||
                         (tag.getAttribute("name") === "description" && tag.getAttribute("content") === "Test description") ||
-                        (tag.getAttribute("http-equiv") === "content-type" && tag.getAttribute("content") === "text/html");
+                        (tag.getAttribute("http-equiv") === "content-type" && tag.getAttribute("content") === "text/html") ||
+                        (tag.getAttribute("property") === "og-type" && tag.getAttribute("content") === "article") ||
+                        (tag.getAttribute("itemprop") === "name" && tag.getAttribute("content") === "Test name itemprop");
                 });
 
-                expect(filteredTags.length).to.be.at.least(3);
+                expect(filteredTags.length).to.be.at.least(4);
             });
 
             it("will clear all meta tags if none are specified", () => {
@@ -499,7 +502,7 @@ describe("Helmet", () => {
                 expect(existingTags.length).to.equal(0);
             });
 
-            it("tags without 'name', 'http-equiv', 'property', or 'charset' will not be accepted", () => {
+            it("tags without 'name', 'http-equiv', 'property', 'charset', or 'itemProp' will not be accepted", () => {
                 ReactDOM.render(
                     <Helmet
                         meta={[{"href": "won't work"}]}
@@ -1245,7 +1248,8 @@ describe("Helmet", () => {
             `<meta ${HELMET_ATTRIBUTE}="true" charset="utf-8"/>`,
             `<meta ${HELMET_ATTRIBUTE}="true" name="description" content="Test description &amp; encoding of special characters like &#x27; &quot; &gt; &lt; \`"/>`,
             `<meta ${HELMET_ATTRIBUTE}="true" http-equiv="content-type" content="text/html"/>`,
-            `<meta ${HELMET_ATTRIBUTE}="true" property="og:type" content="article"/>`
+            `<meta ${HELMET_ATTRIBUTE}="true" property="og:type" content="article"/>`,
+            `<meta ${HELMET_ATTRIBUTE}="true" itemprop="name" content="Test name itemprop"/>`
         ].join("");
 
         const stringifiedLinkTags = [
@@ -1409,7 +1413,8 @@ describe("Helmet", () => {
                         {"charset": "utf-8"},
                         {"name": "description", "content": "Test description & encoding of special characters like ' \" > < `"},
                         {"http-equiv": "content-type", "content": "text/html"},
-                        {"property": "og:type", "content": "article"}
+                        {"property": "og:type", "content": "article"},
+                        {"itemProp": "name", "content": "Test name itemprop"}
                     ]}
                 />,
                 container
@@ -1424,7 +1429,7 @@ describe("Helmet", () => {
 
             expect(metaComponent)
                 .to.be.an("array")
-                .that.has.length.of(4);
+                .that.has.length.of(5);
 
             metaComponent.forEach(meta => {
                 expect(meta)
@@ -1611,7 +1616,8 @@ describe("Helmet", () => {
                         {"charset": "utf-8"},
                         {"name": "description", "content": "Test description & encoding of special characters like ' \" > < `"},
                         {"http-equiv": "content-type", "content": "text/html"},
-                        {"property": "og:type", "content": "article"}
+                        {"property": "og:type", "content": "article"},
+                        {"itemProp": "name", "content": "Test name itemprop"}
                     ]}
                 />,
                 container

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -154,6 +154,21 @@ describe("Helmet", () => {
 
                 expect(document.title).to.equal(chineseTitle);
             });
+
+            it("page tite with prop itemprop", () => {
+                ReactDOM.render(
+                    <Helmet
+                        title={"Test Title with itemProp"}
+                        titleProps={[{itemProp: 'name'}]}
+                        defaultTitle={"Fallback"}
+                    />,
+                    container
+                );
+
+                const titleTag = document.getElementsByTagName("title")[0];
+                expect(document.title).to.equal("Test Title with itemProp");
+                expect(titleTag.getAttribute("itemprop")).to.equal("name");
+            });
         });
 
         describe("html attributes", () => {
@@ -1223,6 +1238,7 @@ describe("Helmet", () => {
     describe("server", () => {
         const stringifiedHtmlAttribute = `lang="ga"`;
         const stringifiedTitle = `<title ${HELMET_ATTRIBUTE}="true">Dangerous &lt;script&gt; include</title>`;
+        const stringifiedTitleWithItemprop = `<title ${HELMET_ATTRIBUTE}="true" itemprop="name">Title with Itemprop</title>`;
         const stringifiedBaseTag = `<base ${HELMET_ATTRIBUTE}="true" target="_blank" href="http://localhost/"/>`;
 
         const stringifiedMetaTags = [
@@ -1302,6 +1318,49 @@ describe("Helmet", () => {
                 .to.be.a("string")
                 .that.equals(`<div>${
                     stringifiedTitle
+                }</div>`);
+        });
+
+        it("will render title with itemprop name", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Title with Itemprop"}
+                    titleProps={[{itemProp: 'name'}]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toComponent");
+
+            const titleComponent = head.title.toComponent();
+            const titleString = head.title.toString();
+            expect(titleString)
+                .to.be.a("string")
+                .that.equals(stringifiedTitleWithItemprop);
+
+            expect(titleComponent)
+                .to.be.an("array")
+                .that.has.length.of(1);
+
+            titleComponent.forEach(title => {
+                expect(title)
+                    .to.be.an("object")
+                    .that.contains.property("type", "title");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {titleComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedTitleWithItemprop
                 }</div>`);
         });
 


### PR DESCRIPTION
Supporting issue #113.
Usage: 
- For itemProp in meta: 
`<Helmet meta={[{'itemProp': 'image', 'content': 'some_url_here'}]} />`
- For itemProp in title:
`<Helmet title="Your title" titleAttributes={{itemProp: 'name'}} />`