### PR TITLE
Use function callback on titleTemplate string replacement to avoid escaping dollar signs

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -37,7 +37,7 @@ const getTitleFromPropsList = (propsList) => {
 
     if (innermostTemplate && innermostTitle) {
         // use function arg to avoid need to escape $ characters
-        return innermostTemplate.replace(/\%s/g, function () { return innermostTitle; });
+        return innermostTemplate.replace(/\%s/g, () => innermostTitle);
     }
 
     const innermostDefaultTitle = getInnermostProperty(propsList, "defaultTitle");

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -36,7 +36,8 @@ const getTitleFromPropsList = (propsList) => {
     const innermostTemplate = getInnermostProperty(propsList, "titleTemplate");
 
     if (innermostTemplate && innermostTitle) {
-        return innermostTemplate.replace(/\%s/g, innermostTitle);
+        // use function arg to avoid need to escape $ characters
+        return innermostTemplate.replace(/\%s/g, function () { return innermostTitle; });
     }
 
     const innermostDefaultTitle = getInnermostProperty(propsList, "defaultTitle");

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -146,10 +146,8 @@ describe("Helmet", () => {
                 const dollarTitle = "te$t te$$t te$$$t te$$$$t";
 
                 ReactDOM.render(
-                    <div>
-                        <Helmet titleTemplate={"This is a %s"}
-                                title={dollarTitle} />
-                    </div>,
+                    <Helmet titleTemplate={"This is a %s"}
+                            title={dollarTitle} />,
                     container
                 );
 

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -142,6 +142,20 @@ describe("Helmet", () => {
                 expect(document.title).to.equal("This is a Second Test of the titleTemplate feature");
             });
 
+            it("will render dollar characters in a title correctly when titleTemplate present", () => {
+                const dollarTitle = "te$t te$$t te$$$t te$$$$t";
+
+                ReactDOM.render(
+                    <div>
+                        <Helmet titleTemplate={"This is a %s"}
+                                title={dollarTitle} />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal("This is a te$t te$$t te$$$t te$$$$t");
+            });
+
             it("will not encode all characters with HTML character entity equivalents", () => {
                 const chineseTitle = "膣膗 鍆錌雔";
 


### PR DESCRIPTION
Addresses this issue https://github.com/nfl/react-helmet/issues/164