### PR TITLE
Dont update rel="preload" link tags

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -225,6 +225,7 @@ const updateTags = (type, tags) => {
             // Remove a duplicate tag from domTagstoRemove, so it isn't cleared.
             if (oldTags.some((existingTag, index) => {
                 indexToDelete = index;
+                // special condition for link tags with rel="preload" to prevent them from being updated
                 if (type === 'link' && newElement.rel === 'preload') {
                     return newElement.href === existingTag.href;
                 }

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -21,7 +21,7 @@ const encodeSpecialCharacters = (str) => {
 };
 
 const getInnermostProperty = (propsList, property) => {
-    for(let i = propsList.length - 1; i >= 0; i--) {
+    for (let i = propsList.length - 1; i >= 0; i--) {
         const props = propsList[i];
 
         if (props[property]) {
@@ -225,6 +225,9 @@ const updateTags = (type, tags) => {
             // Remove a duplicate tag from domTagstoRemove, so it isn't cleared.
             if (oldTags.some((existingTag, index) => {
                 indexToDelete = index;
+                if (type === 'link' && newElement.rel === 'preload') {
+                    return newElement.href === existingTag.href;
+                }
                 return newElement.isEqualNode(existingTag);
             })) {
                 oldTags.splice(indexToDelete, 1);

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -984,6 +984,55 @@ describe("Helmet", () => {
                 expect(secondTag.getAttribute("href")).to.equal("http://localhost/helmet/innercomponent");
                 expect(secondTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/innercomponent" ${HELMET_ATTRIBUTE}="true">`);
             });
+
+            it("will not update preload links", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"rel": "canonical", "href": "http://localhost/helmet"},
+                            {"rel": "preload", "href": "http://localhost/style.css", "as": "style", "type": "text/css"}
+                        ]}
+                    />,
+                    container
+                );
+
+                headElement.querySelectorAll('link[rel="preload"]')[0].setAttribute('rel', 'stylesheet');
+
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"rel": "canonical", "href": "http://localhost/helmet"},
+                            {"rel": "preload", "href": "http://localhost/style.css", "as": "style", "type": "text/css"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.at.least(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("rel")).to.equal("canonical");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/helmet");
+                expect(firstTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("rel")).to.equal("stylesheet");
+                expect(secondTag.getAttribute("href")).to.equal("http://localhost/style.css");
+                expect(secondTag.outerHTML).to.equal(`<link rel="stylesheet" href="http://localhost/style.css" as="style" type="text/css" ${HELMET_ATTRIBUTE}="true">`);
+            });
         });
 
         describe("script tags", () => {


### PR DESCRIPTION
Prevent updating of link tags with rel="preload" as outlined in #170.