### PR TITLE
Allow versions of Node newer than 6.6.0, including Node 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/nfl/react-helmet"
   },
   "engines": {
-    "node": "6.6.0",
+    "node": "^6.6.0 || ^7.0.0",
     "npm": "3.10.3"
   },
   "keywords": [


### PR DESCRIPTION
react-helmet runs correctly on Node 6.6+ as well as 7.x -- this PR adds those versions of Node to the "engines" list.