### PR TITLE
FIX #190 - Removed reference to es module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "description": "A document head manager for React",
   "version": "3.2.1",
   "main": "./lib/Helmet.js",
-  "module": "es/Helmet.js",
-  "jsnext:main": "es/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [
     "Chris Welch <chris.welch@nfl.com>"


### PR DESCRIPTION
Have removed the reference to `module` and `jsnext:main` for es6 use for now.

Have kept the es build.

Wait for a major release to change how you export and import the package in a project.