### PR TITLE
Prevent server rendered tag clobbering

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -59,9 +59,13 @@ const getHtmlAttributesFromPropsList = (propsList) => {
 };
 
 const getBaseTagFromPropsList = (primaryAttributes, propsList) => {
-    return propsList
-        .filter(props => typeof props[TAG_NAMES.BASE] !== "undefined")
-        .map(props => props[TAG_NAMES.BASE])
+  const propTags = propsList
+      .filter(props => typeof props[TAG_NAMES.BASE] !== "undefined")
+      .map(props => props[TAG_NAMES.BASE]);
+
+    if (!propTags.length) return null;
+
+    return propTags
         .reverse()
         .reduce((innermostBaseTag, tag) => {
             if (!innermostBaseTag.length) {
@@ -85,9 +89,13 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
     // Calculate list of tags, giving priority innermost component (end of the propslist)
     const approvedSeenTags = {};
 
-    const tagList = propsList
+    const propTags = propsList
         .filter(props => typeof props[tagName] !== "undefined")
-        .map(props => props[tagName])
+        .map(props => props[tagName]);
+
+    if (!propTags.length) return null;
+
+    const tagList = propTags
         .reverse()
         .reduce((approvedTags, instanceTags) => {
             const instanceSeenTags = {};
@@ -199,6 +207,13 @@ const updateTags = (type, tags) => {
     const newTags = [];
     let indexToDelete;
 
+    const updatedTags = {
+        oldTags,
+        newTags
+    }
+
+    if (tags === null) return updatedTags;
+
     if (tags && tags.length) {
         tags
         .forEach(tag => {
@@ -238,10 +253,7 @@ const updateTags = (type, tags) => {
     oldTags.forEach(tag => tag.parentNode.removeChild(tag));
     newTags.forEach(tag => headElement.appendChild(tag));
 
-    return {
-        oldTags,
-        newTags
-    };
+    return updatedTags;
 };
 
 const generateHtmlAttributesAsString = (attributes) => {


### PR DESCRIPTION
Close #98 

This will return `null` from the `getBaseTagFromPropsList` and `getTagsFromPropsList` when there are no props defined in the aggregated `propsList`. This allows us to exit early inside `updateTags` and prevent removing tags which were rendered on the server-side render. If a blank array is passed through it will still remove the server rendered tags correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nfl/react-helmet/201)
<!-- Reviewable:end -->
