### PR TITLE
map className to class when updating htmlAttributes

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -5,8 +5,7 @@ import objectAssign from "object-assign";
 import {
     TAG_NAMES,
     TAG_PROPERTIES,
-    REACT_TAG_MAP,
-    HTML_TAG_MAP
+    REACT_TAG_MAP
 } from "./HelmetConstants.js";
 import PlainComponent from "./PlainComponent";
 
@@ -169,16 +168,14 @@ const updateAttributes = (tagName, attributes) => {
     const attributesToRemove = [].concat(helmetAttributes);
 
     Object.keys(attributes).forEach((attribute) => {
-        const mappedAttribute = HTML_TAG_MAP[attribute] || attribute;
-
         const value = attributes[attribute] || "";
-        htmlTag.setAttribute(mappedAttribute, value);
+        htmlTag.setAttribute(attribute, value);
 
-        if (helmetAttributes.indexOf(mappedAttribute) === -1) {
-            helmetAttributes.push(mappedAttribute);
+        if (helmetAttributes.indexOf(attribute) === -1) {
+            helmetAttributes.push(attribute);
         }
 
-        const indexToSave = attributesToRemove.indexOf(mappedAttribute);
+        const indexToSave = attributesToRemove.indexOf(attribute);
         if (indexToSave !== -1) {
             attributesToRemove.splice(indexToSave, 1);
         }
@@ -253,8 +250,7 @@ const generateHtmlAttributesAsString = (attributes) => {
 
     for (let i = 0; i < keys.length; i++) {
         const attribute = keys[i];
-        const mappedAttribute = HTML_TAG_MAP[attribute] || attribute;
-        const attr = typeof attributes[attribute] !== "undefined" ? `${mappedAttribute}="${attributes[attribute]}"` : `${mappedAttribute}`;
+        const attr = typeof attributes[attribute] !== "undefined" ? `${attribute}="${attributes[attribute]}"` : `${attribute}`;
         attributeString += `${attr} `;
     }
 

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -253,7 +253,8 @@ const generateHtmlAttributesAsString = (attributes) => {
 
     for (let i = 0; i < keys.length; i++) {
         const attribute = keys[i];
-        const attr = typeof attributes[attribute] !== "undefined" ? `${attribute}="${attributes[attribute]}"` : `${attribute}`;
+        const mappedAttribute = HTML_TAG_MAP[attribute] || attribute;
+        const attr = typeof attributes[attribute] !== "undefined" ? `${mappedAttribute}="${attributes[attribute]}"` : `${mappedAttribute}`;
         attributeString += `${attr} `;
     }
 

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -5,7 +5,8 @@ import objectAssign from "object-assign";
 import {
     TAG_NAMES,
     TAG_PROPERTIES,
-    REACT_TAG_MAP
+    REACT_TAG_MAP,
+    HTML_TAG_MAP
 } from "./HelmetConstants.js";
 import PlainComponent from "./PlainComponent";
 
@@ -166,22 +167,22 @@ const updateAttributes = (tagName, attributes) => {
     const helmetAttributeString = htmlTag.getAttribute(HELMET_ATTRIBUTE);
     const helmetAttributes = helmetAttributeString ? helmetAttributeString.split(",") : [];
     const attributesToRemove = [].concat(helmetAttributes);
-    const attributeKeys = Object.keys(attributes);
 
-    for (let i = 0; i < attributeKeys.length; i++) {
-        const attribute = attributeKeys[i];
+    Object.keys(attributes).forEach((attribute) => {
+        const mappedAttribute = HTML_TAG_MAP[attribute] || attribute;
+
         const value = attributes[attribute] || "";
-        htmlTag.setAttribute(attribute, value);
+        htmlTag.setAttribute(mappedAttribute, value);
 
-        if (helmetAttributes.indexOf(attribute) === -1) {
-            helmetAttributes.push(attribute);
+        if (helmetAttributes.indexOf(mappedAttribute) === -1) {
+            helmetAttributes.push(mappedAttribute);
         }
 
-        const indexToSave = attributesToRemove.indexOf(attribute);
+        const indexToSave = attributesToRemove.indexOf(mappedAttribute);
         if (indexToSave !== -1) {
             attributesToRemove.splice(indexToSave, 1);
         }
-    }
+    });
 
     for (let i = attributesToRemove.length - 1; i >= 0; i--) {
         htmlTag.removeAttribute(attributesToRemove[i]);
@@ -347,15 +348,6 @@ const generateTagsAsReactComponent = (type, tags) => {
     /* eslint-enable react/display-name */
 };
 
-const mapAttributesForServer = (tags) => {
-    const mappedTags = objectAssign({}, tags);
-    if (mappedTags["class"]) {
-        mappedTags.className = mappedTags["class"];
-        delete mappedTags["class"];
-    }
-    return mappedTags;
-};
-
 const getMethodsForTag = (type, tags) => {
     switch (type) {
         case TAG_NAMES.TITLE:
@@ -365,7 +357,7 @@ const getMethodsForTag = (type, tags) => {
             };
         case TAG_NAMES.HTML:
             return {
-                toComponent: () => mapAttributesForServer(tags),
+                toComponent: () => tags,
                 toString: () => generateHtmlAttributesAsString(tags)
             };
         default:

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -347,6 +347,15 @@ const generateTagsAsReactComponent = (type, tags) => {
     /* eslint-enable react/display-name */
 };
 
+const mapAttributesForServer = (tags) => {
+    const mappedTags = objectAssign({}, tags);
+    if (mappedTags["class"]) {
+        mappedTags.className = mappedTags["class"];
+        delete mappedTags["class"];
+    }
+    return mappedTags;
+};
+
 const getMethodsForTag = (type, tags) => {
     switch (type) {
         case TAG_NAMES.TITLE:
@@ -356,7 +365,7 @@ const getMethodsForTag = (type, tags) => {
             };
         case TAG_NAMES.HTML:
             return {
-                toComponent: () => tags,
+                toComponent: () => mapAttributesForServer(tags),
                 toString: () => generateHtmlAttributesAsString(tags)
             };
         default:

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -25,9 +25,6 @@ export const TAG_PROPERTIES = {
 export const REACT_TAG_MAP = {
     "charset": "charSet",
     "http-equiv": "httpEquiv",
-    "itemprop": "itemProp"
-};
-
-export const HTML_TAG_MAP = {
-    "className": "class"
+    "itemprop": "itemProp",
+    "class": "className"
 };

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -27,3 +27,7 @@ export const REACT_TAG_MAP = {
     "http-equiv": "httpEquiv",
     "itemprop": "itemProp"
 };
+
+export const HTML_TAG_MAP = {
+    "className": "class"
+};

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -349,7 +349,7 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         htmlAttributes={{
-                            "className": "myClassName"
+                            "class": "myClassName"
                         }}
                     />,
                     container
@@ -2067,7 +2067,7 @@ describe("Helmet", () => {
                 <Helmet
                     htmlAttributes={{
                         lang: "ga",
-                        className: "myClassName"
+                        class: "myClassName"
                     }}
                 />,
                 container

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -1512,7 +1512,7 @@ describe("Helmet", () => {
     });
 
     describe("server", () => {
-        const stringifiedHtmlAttribute = `lang="ga"`;
+        const stringifiedHtmlAttributes = `lang="ga" class="myClassName"`;
         const stringifiedTitle = `<title ${HELMET_ATTRIBUTE}="true">Dangerous &lt;script&gt; include</title>`;
         const stringifiedTitleWithItemprop = `<title ${HELMET_ATTRIBUTE}="true" itemprop="name">Title with Itemprop</title>`;
         const stringifiedBaseTag = `<base ${HELMET_ATTRIBUTE}="true" target="_blank" href="http://localhost/"/>`;
@@ -2037,34 +2037,11 @@ describe("Helmet", () => {
                 .that.equals(stringifiedStyleTags);
         });
 
-        it("will render html attributes as component", () => {
-            ReactDOM.render(
-                <Helmet
-                    htmlAttributes={{
-                        lang: "ga"
-                    }}
-                />,
-                container
-            );
-
-            const {htmlAttributes} = Helmet.rewind();
-            const attrs = htmlAttributes.toComponent();
-
-            expect(attrs).to.exist;
-
-            const markup = ReactServer.renderToStaticMarkup(
-                <html lang="en" {...attrs} />
-            );
-
-            expect(markup)
-                .to.be.a("string")
-                .that.equals(`<html ${stringifiedHtmlAttribute}></html>`);
-        });
-
         it("will render html class attribute as component", () => {
             ReactDOM.render(
                 <Helmet
                     htmlAttributes={{
+                        lang: "ga",
                         className: "myClassName"
                     }}
                 />,
@@ -2082,33 +2059,14 @@ describe("Helmet", () => {
 
             expect(markup)
                 .to.be.a("string")
-                .that.equals(`<html class="myClassName"></html>`);
+                .that.equals(`<html ${stringifiedHtmlAttributes}></html>`);
         });
 
         it("will render html attributes as string", () => {
             ReactDOM.render(
                 <Helmet
                     htmlAttributes={{
-                        lang: "ga"
-                    }}
-                />,
-                container
-            );
-
-            const head = Helmet.rewind();
-
-            expect(head.htmlAttributes).to.exist;
-            expect(head.htmlAttributes).to.respondTo("toString");
-
-            expect(head.htmlAttributes.toString())
-                .to.be.a("string")
-                .that.equals(stringifiedHtmlAttribute);
-        });
-
-        it("maps attributes to html attributes", () => {
-            ReactDOM.render(
-                <Helmet
-                    htmlAttributes={{
+                        lang: "ga",
                         className: "myClassName"
                     }}
                 />,
@@ -2122,7 +2080,7 @@ describe("Helmet", () => {
 
             expect(head.htmlAttributes.toString())
                 .to.be.a("string")
-                .that.equals(`class="myClassName"`);
+                .that.equals(stringifiedHtmlAttributes);
         });
 
         it("will not encode all characters with HTML character entity equivalents", () => {

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -2061,6 +2061,30 @@ describe("Helmet", () => {
                 .that.equals(`<html ${stringifiedHtmlAttribute}></html>`);
         });
 
+        it("will render html class attribute as component", () => {
+            ReactDOM.render(
+                <Helmet
+                    htmlAttributes={{
+                        className: "myClassName"
+                    }}
+                />,
+                container
+            );
+
+            const {htmlAttributes} = Helmet.rewind();
+            const attrs = htmlAttributes.toComponent();
+
+            expect(attrs).to.exist;
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <html {...attrs} />
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<html class="myClassName"></html>`);
+        });
+
         it("will render html attributes as string", () => {
             ReactDOM.render(
                 <Helmet
@@ -2079,6 +2103,26 @@ describe("Helmet", () => {
             expect(head.htmlAttributes.toString())
                 .to.be.a("string")
                 .that.equals(stringifiedHtmlAttribute);
+        });
+
+        it("maps attributes to html attributes", () => {
+            ReactDOM.render(
+                <Helmet
+                    htmlAttributes={{
+                        className: "myClassName"
+                    }}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.htmlAttributes).to.exist;
+            expect(head.htmlAttributes).to.respondTo("toString");
+
+            expect(head.htmlAttributes.toString())
+                .to.be.a("string")
+                .that.equals(`class="myClassName"`);
         });
 
         it("will not encode all characters with HTML character entity equivalents", () => {

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -345,6 +345,22 @@ describe("Helmet", () => {
                 expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
             });
 
+            it("maps attributes to html attributes", () => {
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "className": "myClassName"
+                        }}
+                    />,
+                    container
+                );
+
+                const htmlTag = document.getElementsByTagName("html")[0];
+
+                expect(htmlTag.getAttribute("class")).to.equal("myClassName");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("class");
+            });
+
             context("initialized outside of helmet", () => {
                 before(() => {
                     const htmlTag = document.getElementsByTagName("html")[0];


### PR DESCRIPTION
This introduces a mapping of React attributes (e.g. `className`) to html attributes (`class`). 
If other attributes have to be mapped later on they can be added easily to the `HTML_TAG_MAP` object.

should fix #204 