### PR TITLE
Drops separate PlainComponent file, makes series of small optimizations

### DIFF
--- a/src/PlainComponent.js
+++ b/src/PlainComponent.js
@@ -1,7 +1,0 @@
-import React from "react";
-
-export default class PlainComponent extends React.Component {
-    render() {
-        return null;
-    }
-}


### PR DESCRIPTION
- Since all PlainComponent did was render null, there's no need to make
it class-based or a separate file. Doing a null-returning function
inline saves some overhead
- Refactored some functions to use `reduce` and insert the spaces within
the higher-order function instead of joining and trimming afterward
- Adds explicit name/reference for HelmetSideEffects and passes that to
the Helmet wrapper
- Makes some small changes around indentation, returning earlier, and
implicit returns from arrow functions