### PR TITLE
Put back in the optimization that broken 3.3.1 build - PlainComponent…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [4.0.0](#400)
 - [3.3.2](#332)
 - [3.3.1 [BROKEN]](#331-broken)
 - [3.3.0](#330)
@@ -29,6 +30,12 @@
 - [1.0.0](#100)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+## 4.0.0
+
+Features:
+
+  - Replacing PlainComponent with stateless functional component `NullComponent`, with a hard requirement to use React 15 or higher.
+
 ## 3.3.2
 
 Bugfixes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "3.3.2",
+  "version": "4.0.0",
   "main": "./lib/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [
@@ -24,6 +24,9 @@
     "script",
     "base"
   ],
+  "peerDependencies": {
+    "react": ">=15.0.0"
+  },
   "dependencies": {
     "deep-equal": "1.0.1",
     "object-assign": "^4.0.1",

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -7,7 +7,6 @@ import {
     TAG_PROPERTIES,
     REACT_TAG_MAP
 } from "./HelmetConstants.js";
-import PlainComponent from "./PlainComponent";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 
@@ -466,10 +465,12 @@ const handleClientStateChange = (newState) => {
     onChangeClientState(newState, addedTags, removedTags);
 };
 
+const NullComponent = () => null;
+
 const HelmetSideEffects = withSideEffect(
     reducePropsToState,
     handleClientStateChange,
     mapStateOnServer
-)(PlainComponent);
+)(NullComponent);
 
 export default Helmet(HelmetSideEffects);

--- a/src/PlainComponent.js
+++ b/src/PlainComponent.js
@@ -1,7 +1,0 @@
-import React from "react";
-
-export default class PlainComponent extends React.Component {
-    render() {
-        return null;
-    }
-}


### PR DESCRIPTION
… replaced with stateless functional component `NullComponent`.  Added peerDependencies to enforce React 15 or higher.