### PR TITLE
(fix) fail gracefully if prop is not an Array and issue warning

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -86,7 +86,15 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
     const approvedSeenTags = {};
 
     return propsList
-        .filter(props => typeof props[tagName] !== "undefined")
+        .filter((props) => {
+            if (Array.isArray(props[tagName])) {
+                return true;
+            }
+            if (typeof props[tagName] !== "undefined") {
+                warn(`Helmet: ${tagName} should be of type "Array". Instead found type "${typeof props[tagName]}"`);
+            }
+            return false;
+        })
         .map(props => props[tagName])
         .reverse()
         .reduce((approvedTags, instanceTags) => {
@@ -463,6 +471,10 @@ const handleClientStateChange = (newState) => {
     });
 
     onChangeClientState(newState, addedTags, removedTags);
+};
+
+const warn = (msg) => {
+    return console && typeof console.warn === "function" && console.warn(msg);
 };
 
 const NullComponent = () => null;

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -881,7 +881,7 @@ describe("Helmet", () => {
 
                 const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
                 const existingTags = Array.prototype.slice.call(tagNodes);
-                console.log("existingTags", existingTags);
+                expect(existingTags).to.be.empty;
             });
         });
 

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -870,6 +870,19 @@ describe("Helmet", () => {
                 const existingTags = Array.prototype.slice.call(tagNodes);
                 expect(existingTags).to.be.empty;
             });
+
+            it("fails gracefully when meta is wrong shape", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={{"name": "title", "content": "some title"}}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                console.log("existingTags", existingTags);
+            });
         });
 
         describe("link tags", () => {


### PR DESCRIPTION
Potential fix for #220 to fail gracefully is propType is not an Array also issue a descriptive warning. 