### PR TITLE
Helmet 5.0.0: The no-API release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "main": "./lib/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "5.0.0-beta",
+  "version": "5.0.0-beta.2",
   "main": "./lib/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "main": "./lib/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "4.0.0",
+  "version": "5.0.0-beta",
   "main": "./lib/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -397,10 +397,10 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
      * @param {Object} htmlAttributes: {"lang": "en", "amp": undefined}
      * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example"}]
      * @param {Array} meta: [{"name": "description", "content": "Test description"}]
-     * @param {Array} noscript: [{TAG_PROPERTIES.INNER_HTML: "<img src='http://mysite.com/js/test.js'"}]
+     * @param {Array} noscript: [{"innerHTML": "<img src='http://mysite.com/js/test.js'"}]
      * @param {Function} onChangeClientState: "(newState) => console.log(newState)"
      * @param {Array} script: [{"type": "text/javascript", "src": "http://mysite.com/js/test.js"}]
-     * @param {Array} style: [{"type": "text/css", TAG_PROPERTIES.CSS_TEXT: "div{ display: block; color: blue; }"}]
+     * @param {Array} style: [{"type": "text/css", "cssText": "div { display: block; color: blue; }"}]
      * @param {String} title: "Title"
      * @param {Object} titleAttributes: {"itemprop": "name"}
      * @param {String} titleTemplate: "MySite.com - %s"

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -384,13 +384,13 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
             React.PropTypes.arrayOf(React.PropTypes.node),
             React.PropTypes.node
         ])
-    }
+    };
 
     // Component.peek comes from react-side-effect:
     // For testing, you may use a static peek() method available on the returned component.
     // It lets you get the current state without resetting the mounted instance stack.
     // Don’t use it for anything other than testing.
-    static peek = Component.peek
+    static peek = Component.peek;
 
     static rewind = () => {
         let mappedState = Component.rewind();
@@ -410,7 +410,7 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
         }
 
         return mappedState;
-    }
+    };
 
     static set canUseDOM(canUseDOM) {
         Component.canUseDOM = canUseDOM;
@@ -586,4 +586,7 @@ const HelmetSideEffects = withSideEffect(
     mapStateOnServer
 )(NullComponent);
 
-export default Helmet(HelmetSideEffects);
+const HelmetExport = Helmet(HelmetSideEffects);
+
+export {HelmetExport as Helmet};
+export default HelmetExport;

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -426,8 +426,12 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
                     case "script":
                     case "style":
                     case "noscript":
-                        if (process.env.NODE_ENV !== "production" && typeof child.props.children !== "string") {
-                            console.warn(`Helmet only expects single string as a child of ${child.type}`);
+                        if (
+                            process.env.NODE_ENV !== "production" &&
+                            child.props.children &&
+                            typeof child.props.children !== "string"
+                        ) {
+                            console.warn(`Helmet expects a single string as a child of ${child.type}`);
                         }
                         newProps = {
                             ...newProps,

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -379,7 +379,7 @@ const mapStateOnServer = ({
     titleAttributes
 }) => ({
     base: getMethodsForTag(TAG_NAMES.BASE, baseTag),
-    bodyAttributes: getMethodsForTag(ATTRIBUTE_NAMES.HTML, bodyAttributes),
+    bodyAttributes: getMethodsForTag(ATTRIBUTE_NAMES.BODY, bodyAttributes),
     htmlAttributes: getMethodsForTag(ATTRIBUTE_NAMES.HTML, htmlAttributes),
     link: getMethodsForTag(TAG_NAMES.LINK, linkTags),
     meta: getMethodsForTag(TAG_NAMES.META, metaTags),

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -587,6 +587,7 @@ const HelmetSideEffects = withSideEffect(
 )(NullComponent);
 
 const HelmetExport = Helmet(HelmetSideEffects);
+HelmetExport.renderStatic = HelmetExport.rewind;
 
 export {HelmetExport as Helmet};
 export default HelmetExport;

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -422,15 +422,15 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
 
         if (children) {
             React.Children.forEach(children, (child) => {
-                const mappedProps = Object.keys(child.props).reduce((obj, key) => {
+                const newChildProps = Object.keys(child.props).reduce((obj, key) => {
                     obj[(HTML_TAG_MAP[key] || key)] = child.props[key];
                     return obj;
                 }, {});
 
                 if (
                     process.env.NODE_ENV !== "production" &&
-                    mappedProps.children &&
-                    typeof mappedProps.children !== "string"
+                    newChildProps.children &&
+                    typeof newChildProps.children !== "string"
                 ) {
                     console.warn(`Helmet expects a single string as a child of ${child.type}`);
                 }
@@ -441,21 +441,28 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
                     case "noscript":
                         newProps = {
                             ...newProps,
-                            [child.type]: mappedProps.children
+                            [child.type]: newChildProps.children
                         };
                         break;
                     case "title":
                         newProps = {
                             ...newProps,
-                            [child.type]: mappedProps.children,
-                            titleAttributes: {...mappedProps}
+                            [child.type]: newChildProps.children,
+                            titleAttributes: {...newChildProps}
+                        };
+                        break;
+                    case "html":
+                        newProps = {
+                            ...newProps,
+                            htmlAttributes: {...newChildProps}
                         };
                         break;
                     default:
                         newProps = {
                             ...newProps,
-                            [child.type]: {...mappedProps}
+                            [child.type]: {...newChildProps}
                         };
+                        break;
                 }
             });
         }

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -283,16 +283,20 @@ const generateTagsAsString = (type, tags) => tags.reduce((str, tag) => {
     return `${str}<${type} ${HELMET_ATTRIBUTE}="true" ${attributeHtml}${isSelfClosing ? `/>` : `>${tagContent}</${type}>`}`;
 }, "");
 
+const convertHtmlAttributestoReactProps = (attributes, initProps = {}) => {
+    return Object.keys(attributes).reduce((obj, key) => {
+        obj[(REACT_TAG_MAP[key] || key)] = attributes[key];
+        return obj;
+    }, initProps);
+};
+
 const generateTitleAsReactComponent = (type, title, attributes) => {
     // assigning into an array to define toString function on it
     const initProps = {
         key: title,
         [HELMET_ATTRIBUTE]: true
     };
-    const props = Object.keys(attributes).reduce((obj, key) => {
-        obj[(REACT_TAG_MAP[key] || key)] = attributes[key];
-        return obj;
-    }, initProps);
+    const props = convertHtmlAttributestoReactProps(attributes, initProps);
 
     return [React.createElement(TAG_NAMES.TITLE, props, title)];
 };
@@ -326,7 +330,7 @@ const getMethodsForTag = (type, tags) => {
             };
         case TAG_NAMES.HTML:
             return {
-                toComponent: () => tags,
+                toComponent: () => convertHtmlAttributestoReactProps(tags),
                 toString: () => generateHtmlAttributesAsString(tags)
             };
         default:

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -421,6 +421,8 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
         let newProps = {...props};
 
         if (children) {
+            let arrayTypeChildren = {};
+
             React.Children.forEach(children, (child) => {
                 const newChildProps = Object.keys(child.props).reduce((obj, key) => {
                     obj[(HTML_TAG_MAP[key] || key)] = child.props[key];
@@ -436,12 +438,17 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
                 }
 
                 switch (child.type) {
+                    case "meta":
+                    case "link":
                     case "script":
-                    case "style":
                     case "noscript":
-                        newProps = {
-                            ...newProps,
-                            [child.type]: newChildProps.children
+                    case "style":
+                        arrayTypeChildren = {
+                            ...arrayTypeChildren,
+                            [child.type]: [
+                                ...arrayTypeChildren[child.type] || [],
+                                newChildProps
+                            ]
                         };
                         break;
                     case "title":
@@ -465,6 +472,14 @@ const Helmet = (Component) => class HelmetWrapper extends React.Component {
                         break;
                 }
             });
+
+            Object.keys(arrayTypeChildren)
+                .forEach(arrayChildName => {
+                    newProps = {
+                        ...newProps,
+                        [arrayChildName]: arrayTypeChildren[arrayChildName]
+                    };
+                });
         }
 
         return <Component {...newProps} />;

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -1,37 +1,55 @@
-export const TAG_NAMES = {
+export const ATTRIBUTE_NAMES = {
+    BODY: "bodyAttributes",
     HTML: "htmlAttributes",
-    TITLE: "title",
+    TITLE: "titleAttributes"
+};
+
+export const TAG_NAMES = {
     BASE: "base",
-    META: "meta",
+    BODY: "body",
+    HEAD: "head",
+    HTML: "html",
     LINK: "link",
-    SCRIPT: "script",
+    META: "meta",
     NOSCRIPT: "noscript",
-    STYLE: "style"
+    SCRIPT: "script",
+    STYLE: "style",
+    TITLE: "title"
 };
 
 export const TAG_PROPERTIES = {
-    NAME: "name",
     CHARSET: "charset",
-    HTTPEQUIV: "http-equiv",
-    REL: "rel",
-    HREF: "href",
-    PROPERTY: "property",
-    SRC: "src",
-    INNER_HTML: "innerHTML",
     CSS_TEXT: "cssText",
-    ITEM_PROP: "itemprop"
+    HREF: "href",
+    HTTPEQUIV: "http-equiv",
+    INNER_HTML: "innerHTML",
+    ITEM_PROP: "itemprop",
+    NAME: "name",
+    PROPERTY: "property",
+    REL: "rel",
+    SRC: "src"
 };
 
 export const REACT_TAG_MAP = {
     "charset": "charSet",
+    "class": "className",
     "http-equiv": "httpEquiv",
-    "itemprop": "itemProp",
-    "class": "className"
+    "itemprop": "itemProp"
+};
+
+export const HELMET_PROPS = {
+    DEFAULT_TITLE: "defaultTitle",
+    ON_CHANGE_CLIENT_STATE: "onChangeClientState",
+    TITLE_TEMPLATE: "titleTemplate"
 };
 
 export const HTML_TAG_MAP = {
     "charSet": "charset",
+    "className": "class",
     "httpEquiv": "http-equiv",
-    "itemProp": "itemprop",
-    "className": "class"
+    "itemProp": "itemprop"
 };
+
+export const SELF_CLOSING_TAGS = [TAG_NAMES.NOSCRIPT, TAG_NAMES.SCRIPT, TAG_NAMES.STYLE];
+
+export const HELMET_ATTRIBUTE = "data-react-helmet";

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -31,10 +31,14 @@ export const TAG_PROPERTIES = {
 };
 
 export const REACT_TAG_MAP = {
+    "accesskey": "accessKey",
     "charset": "charSet",
     "class": "className",
+    "contenteditable": "contentEditable",
+    "contextmenu": "contextMenu",
     "http-equiv": "httpEquiv",
-    "itemprop": "itemProp"
+    "itemprop": "itemProp",
+    "tabindex": "tabIndex"
 };
 
 export const HELMET_PROPS = {
@@ -43,12 +47,12 @@ export const HELMET_PROPS = {
     TITLE_TEMPLATE: "titleTemplate"
 };
 
-export const HTML_TAG_MAP = {
-    "charSet": "charset",
-    "className": "class",
-    "httpEquiv": "http-equiv",
-    "itemProp": "itemprop"
-};
+export const HTML_TAG_MAP = Object
+    .keys(REACT_TAG_MAP)
+    .reduce((obj, key) => {
+        obj[REACT_TAG_MAP[key]] = key;
+        return obj;
+    }, {});
 
 export const SELF_CLOSING_TAGS = [TAG_NAMES.NOSCRIPT, TAG_NAMES.SCRIPT, TAG_NAMES.STYLE];
 

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -28,3 +28,10 @@ export const REACT_TAG_MAP = {
     "itemprop": "itemProp",
     "class": "className"
 };
+
+export const HTML_TAG_MAP = {
+    "charSet": "charset",
+    "httpEquiv": "http-equiv",
+    "itemProp": "itemprop",
+    "className": "class"
+};

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -900,22 +900,6 @@ describe("Helmet", () => {
                 const existingTags = Array.prototype.slice.call(tagNodes);
                 expect(existingTags).to.be.empty;
             });
-
-            it("fails gracefully when meta is wrong shape", () => {
-                ReactDOM.render(
-                    <Helmet>
-                        <meta
-                            name="title"
-                            content="some title"
-                        />
-                    </Helmet>,
-                    container
-                );
-
-                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
-                const existingTags = Array.prototype.slice.call(tagNodes);
-                expect(existingTags).to.be.empty;
-            });
         });
 
         describe("link tags", () => {

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -873,12 +873,10 @@ describe("Helmet", () => {
         describe("link tags", () => {
             it("can update link tags", () => {
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {"href": "http://localhost/helmet", "rel": "canonical"},
-                            {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"}
-                        ]}
-                    />,
+                    <Helmet>
+                        <link href="http://localhost/helmet" rel="canonical" />
+                        <link href="http://localhost/style.css" rel="stylesheet" type="text/css" />
+                    </Helmet>,
                     container
                 );
 
@@ -897,11 +895,9 @@ describe("Helmet", () => {
 
             it("will clear all link tags if none are specified", () => {
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {"href": "http://localhost/helmet", "rel": "canonical"}
-                        ]}
-                    />,
+                    <Helmet>
+                        <link href="http://localhost/helmet" rel="canonical" />
+                    </Helmet>,
                     container
                 );
 
@@ -919,9 +915,9 @@ describe("Helmet", () => {
 
             it("tags without 'href' or 'rel' will not be accepted, even if they are valid for other tags", () => {
                 ReactDOM.render(
-                    <Helmet
-                        link={[{"http-equiv": "won't work"}]}
-                    />,
+                    <Helmet>
+                        <link httpEquiv="won't work" />
+                    </Helmet>,
                     container
                 );
 
@@ -935,15 +931,15 @@ describe("Helmet", () => {
             it("tags 'rel' and 'href' will properly use 'rel' as the primary identification for this tag, regardless of ordering", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet
-                            link={[{"href": "http://localhost/helmet", "rel": "canonical"}]}
-                        />
-                        <Helmet
-                            link={[{"rel": "canonical", "href": "http://localhost/helmet/new"}]}
-                        />
-                        <Helmet
-                            link={[{"href": "http://localhost/helmet/newest", "rel": "canonical"}]}
-                        />
+                        <Helmet>
+                            <link href="http://localhost/helmet" rel="canonical" />
+                        </Helmet>
+                        <Helmet>
+                            <link rel="canonical" href="http://localhost/helmet/new" />
+                        </Helmet>
+                        <Helmet>
+                            <link href="http://localhost/helmet/newest" rel="canonical" />
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -968,16 +964,22 @@ describe("Helmet", () => {
             it("tags with rel='stylesheet' will use the href as the primary identification of the tag, regardless of ordering", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet
-                            link={[
-                                {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css", "media": "all"}
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {"rel": "stylesheet", "href": "http://localhost/inner.css", "type": "text/css", "media": "all"}
-                            ]}
-                        />
+                        <Helmet>
+                            <link
+                                href="http://localhost/style.css"
+                                rel="stylesheet"
+                                type="text/css"
+                                media="all"
+                            />
+                        </Helmet>
+                        <Helmet>
+                            <link
+                                rel="stylesheet"
+                                href="http://localhost/inner.css"
+                                type="text/css"
+                                media="all"
+                            />
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -1015,18 +1017,24 @@ describe("Helmet", () => {
             it("will set link tags based on deepest nested component", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet
-                            link={[
-                                {"rel": "canonical", "href": "http://localhost/helmet"},
-                                {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css", "media": "all"}
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {"rel": "canonical", "href": "http://localhost/helmet/innercomponent"},
-                                {"href": "http://localhost/inner.css", "rel": "stylesheet", "type": "text/css", "media": "all"}
-                            ]}
-                        />
+                        <Helmet>
+                            <link rel="canonical" href="http://localhost/helmet" />
+                            <link
+                                href="http://localhost/style.css"
+                                rel="stylesheet"
+                                type="text/css"
+                                media="all"
+                            />
+                        </Helmet>
+                        <Helmet>
+                            <link rel="canonical" href="http://localhost/helmet/innercomponent" />
+                            <link
+                                href="http://localhost/inner.css"
+                                rel="stylesheet"
+                                type="text/css"
+                                media="all"
+                            />
+                        </Helmet>
                     </div>,
                     container
                 );

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -2326,8 +2326,7 @@ describe("Helmet", () => {
                         name="description"
                         content="New description"
                     />
-                </Helmet>
-                ,
+                </Helmet>,
                 container
             );
 

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -1969,7 +1969,7 @@ describe("Helmet", () => {
             ReactDOM.render(
                 <Helmet>
                     <meta charSet="utf-8" />
-                    <meta name="description" content="Test description &amp; encoding of special characters like &#x27; &quot; &gt; &lt; \`" />
+                    <meta name="description" content="Test description &amp; encoding of special characters like &#x27; &quot; &gt; &lt; `" />
                     <meta httpEquiv="content-type" content="text/html" />
                     <meta property="og:type" content="article" />
                     <meta itemProp="name" content="Test name itemprop" />

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -5,7 +5,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import ReactServer from "react-dom/server";
-import Helmet from "../Helmet";
+import {Helmet} from "../Helmet";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
 

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -197,9 +197,8 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         defaultTitle={"Fallback"}
-                        titleAttributes={{itemprop: "name"}}
                     >
-                        <title>Test Title with itemProp</title>
+                        <title itemProp="name">Test Title with itemProp</title>
                     </Helmet>,
                     container
                 );
@@ -241,7 +240,7 @@ describe("Helmet", () => {
                 const titleTag = document.getElementsByTagName("title")[0];
 
                 expect(titleTag.getAttribute("lang")).to.equal("ja");
-                expect(titleTag.getAttribute("hidden")).to.equal("");
+                expect(titleTag.getAttribute("hidden")).to.equal("true");
                 expect(titleTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("lang,hidden");
             });
 
@@ -255,7 +254,7 @@ describe("Helmet", () => {
 
                 const titleTag = document.getElementsByTagName("title")[0];
 
-                expect(titleTag.getAttribute("hidden")).to.equal("");
+                expect(titleTag.getAttribute("hidden")).to.equal("true");
                 expect(titleTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("hidden");
             });
 
@@ -325,7 +324,7 @@ describe("Helmet", () => {
 
                 const htmlTag = document.getElementsByTagName("html")[0];
 
-                expect(htmlTag.getAttribute("amp")).to.equal("");
+                expect(htmlTag.getAttribute("amp")).to.equal("true");
                 expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("amp");
             });
 

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -1765,6 +1765,7 @@ describe("Helmet - Declarative API", () => {
 
     describe("server", () => {
         const stringifiedHtmlAttributes = `lang="ga" class="myClassName"`;
+        const stringifiedBodyAttributes = `lang="ga" class="myClassName"`;
         const stringifiedTitle = `<title ${HELMET_ATTRIBUTE}="true">Dangerous &lt;script&gt; include</title>`;
         const stringifiedTitleWithItemprop = `<title ${HELMET_ATTRIBUTE}="true" itemprop="name">Title with Itemprop</title>`;
         const stringifiedBaseTag = `<base ${HELMET_ATTRIBUTE}="true" target="_blank" href="http://localhost/"/>`;
@@ -2295,6 +2296,46 @@ describe("Helmet - Declarative API", () => {
             expect(head.htmlAttributes.toString())
                 .to.be.a("string")
                 .that.equals(stringifiedHtmlAttributes);
+        });
+
+        it("will render body attributes as component", () => {
+            ReactDOM.render(
+                <Helmet>
+                    <body lang="ga" className="myClassName" />
+                </Helmet>,
+                container
+            );
+
+            const {bodyAttributes} = Helmet.rewind();
+            const attrs = bodyAttributes.toComponent();
+
+            expect(attrs).to.exist;
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <body lang="en" {...attrs} />
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<body ${stringifiedBodyAttributes}></body>`);
+        });
+
+        it("will render body attributes as string", () => {
+            ReactDOM.render(
+                <Helmet>
+                    <body lang="ga" className="myClassName" />
+                </Helmet>,
+                container
+            );
+
+            const body = Helmet.rewind();
+
+            expect(body.bodyAttributes).to.exist;
+            expect(body.bodyAttributes).to.respondTo("toString");
+
+            expect(body.bodyAttributes.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedBodyAttributes);
         });
 
         it("will not encode all characters with HTML character entity equivalents", () => {

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -1,5 +1,6 @@
 /* eslint max-nested-callbacks: [1, 5] */
 /* eslint-disable react/jsx-sort-props */
+/* eslint-disable jsx-a11y/html-has-lang */
 
 import React from "react";
 import ReactDOM from "react-dom";

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -2191,6 +2191,63 @@ describe("Helmet - Declarative API", () => {
                 .to.be.a("string")
                 .that.equals(`<script ${HELMET_ATTRIBUTE}="true" src="foo.js" async></script>`);
         });
+
+        context("renderStatic", () => {
+            it("will html encode title", () => {
+                ReactDOM.render(
+                    <Helmet>
+                        <title>{`Dangerous <script> include`}</title>
+                    </Helmet>,
+                    container
+                );
+
+                const head = Helmet.renderStatic();
+
+                expect(head.title).to.exist;
+                expect(head.title).to.respondTo("toString");
+
+                expect(head.title.toString()).to.equal(stringifiedTitle);
+            });
+
+            it("will render title as React component", () => {
+                ReactDOM.render(
+                    <Helmet>
+                        <title>{`Dangerous <script> include`}</title>
+                    </Helmet>,
+                    container
+                );
+
+                const head = Helmet.renderStatic();
+
+                expect(head.title).to.exist;
+                expect(head.title).to.respondTo("toComponent");
+
+                const titleComponent = head.title.toComponent();
+
+                expect(titleComponent)
+                    .to.be.an("array")
+                    .that.has.length.of(1);
+
+                titleComponent.forEach(title => {
+                    expect(title)
+                        .to.be.an("object")
+                        .that.contains.property("type", "title");
+                });
+
+                const markup = ReactServer.renderToStaticMarkup(
+                    <div>
+                        {titleComponent}
+                    </div>
+                );
+
+                expect(markup)
+                    .to.be.a("string")
+                    .that.equals(`<div>${
+                        stringifiedTitle
+                    }</div>`);
+            });
+        });
+
         after(() => {
             Helmet.canUseDOM = true;
         });

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -282,12 +282,9 @@ describe("Helmet", () => {
         describe("html attributes", () => {
             it("update html attributes", () => {
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            "class": "myClassName",
-                            "lang": "en"
-                        }}
-                    />,
+                    <Helmet>
+                        <html className="myClassName" lang="en" />
+                    </Helmet>,
                     container
                 );
 
@@ -301,16 +298,12 @@ describe("Helmet", () => {
             it("set attributes based on the deepest nested component", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet
-                            htmlAttributes={{
-                                "lang": "en"
-                            }}
-                        />
-                        <Helmet
-                            htmlAttributes={{
-                                "lang": "ja"
-                            }}
-                        />
+                        <Helmet>
+                            <html lang="en" />
+                        </Helmet>
+                        <Helmet>
+                            <html lang="ja" />
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -323,11 +316,9 @@ describe("Helmet", () => {
 
             it("handle valueless attributes", () => {
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            "amp": undefined
-                        }}
-                    />,
+                    <Helmet>
+                        <html amp />
+                    </Helmet>,
                     container
                 );
 
@@ -339,12 +330,9 @@ describe("Helmet", () => {
 
             it("clears html attributes that are handled within helmet", () => {
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            "lang": "en",
-                            "amp": undefined
-                        }}
-                    />,
+                    <Helmet>
+                        <html lang="en" amp />
+                    </Helmet>,
                     container
                 );
 
@@ -362,23 +350,16 @@ describe("Helmet", () => {
 
             it("updates with multiple additions and removals - overwrite and new", () => {
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            "lang": "en",
-                            "amp": undefined
-                        }}
-                    />,
+                    <Helmet>
+                        <html lang="en" amp />
+                    </Helmet>,
                     container
                 );
 
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            "lang": "ja",
-                            "id": "html-tag",
-                            "title": "html tag"
-                        }}
-                    />,
+                    <Helmet>
+                        <html lang="ja" id="html-tag" title="html tag" />
+                    </Helmet>,
                     container
                 );
 
@@ -393,22 +374,16 @@ describe("Helmet", () => {
 
             it("updates with multiple additions and removals - all new", () => {
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            "lang": "en",
-                            "amp": undefined
-                        }}
-                    />,
+                    <Helmet>
+                        <html lang="en" amp />
+                    </Helmet>,
                     container
                 );
 
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            "id": "html-tag",
-                            "title": "html tag"
-                        }}
-                    />,
+                    <Helmet>
+                        <html id="html-tag" title="html tag" />
+                    </Helmet>,
                     container
                 );
 
@@ -441,11 +416,9 @@ describe("Helmet", () => {
 
                 it("will be overwritten if specified in helmet", () => {
                     ReactDOM.render(
-                        <Helmet
-                            htmlAttributes={{
-                                "test": "helmet-attr"
-                            }}
-                        />,
+                        <Helmet>
+                            <html test="helmet-attr" />
+                        </Helmet>,
                         container
                     );
 
@@ -457,11 +430,9 @@ describe("Helmet", () => {
 
                 it("can be cleared once it is managed in helmet", () => {
                     ReactDOM.render(
-                        <Helmet
-                            htmlAttributes={{
-                                "test": "helmet-attr"
-                            }}
-                        />,
+                        <Helmet>
+                            <html test="helmet-attr" />
+                        </Helmet>,
                         container
                     );
 

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -26,8 +26,9 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         defaultTitle={"Fallback"}
-                        title={"Test Title"}
-                    />,
+                    >
+                        <title>Test Title</title>
+                    </Helmet>,
                     container
                 );
 
@@ -37,9 +38,15 @@ describe("Helmet", () => {
             it("can update page title with multiple children", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet title={"Test Title"} />
-                        <Helmet title={"Child One Title"} />
-                        <Helmet title={"Child Two Title"} />
+                        <Helmet>
+                            <title>Test Title</title>
+                        </Helmet>
+                        <Helmet>
+                            <title>Child One Title</title>
+                        </Helmet>
+                        <Helmet>
+                            <title>Child Two Title</title>
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -50,8 +57,12 @@ describe("Helmet", () => {
             it("will set title based on deepest nested component", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet title={"Main Title"} />
-                        <Helmet title={"Nested Title"} />
+                        <Helmet>
+                            <title>Main Title</title>
+                        </Helmet>
+                        <Helmet>
+                            <title>Nested Title</title>
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -62,7 +73,9 @@ describe("Helmet", () => {
             it("will set title using deepest nested component with a defined title", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet title={"Main Title"} />
+                        <Helmet>
+                            <title>Main Title</title>
+                        </Helmet>
                         <Helmet />
                     </div>,
                     container
@@ -75,9 +88,10 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         defaultTitle={"Fallback"}
-                        title={""}
                         titleTemplate={"This is a %s of the titleTemplate feature"}
-                    />,
+                    >
+                        <title></title>
+                    </Helmet>,
                     container
                 );
 
@@ -90,7 +104,9 @@ describe("Helmet", () => {
                         defaultTitle={"Fallback"}
                         title={"Test"}
                         titleTemplate={"This is a %s of the titleTemplate feature"}
-                    />,
+                    >
+                        <title>Test</title>
+                    </Helmet>,
                     container
                 );
 
@@ -100,9 +116,10 @@ describe("Helmet", () => {
             it("will replace multiple title strings in titleTemplate", () => {
                 ReactDOM.render(
                     <Helmet
-                        title={"Test"}
                         titleTemplate={"This is a %s of the titleTemplate feature. Another %s."}
-                    />,
+                    >
+                        <title>Test</title>
+                    </Helmet>,
                     container
                 );
 
@@ -113,13 +130,15 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <div>
                         <Helmet
-                            title={"Test"}
                             titleTemplate={"This is a %s of the titleTemplate feature"}
-                        />
+                        >
+                            <title>Test</title>
+                        </Helmet>
                         <Helmet
-                            title={"Second Test"}
                             titleTemplate={"A %s using nested titleTemplate attributes"}
-                        />
+                        >
+                            <title>Second Test</title>
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -131,10 +150,13 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <div>
                         <Helmet
-                            title={"Test"}
                             titleTemplate={"This is a %s of the titleTemplate feature"}
-                        />
-                        <Helmet title={"Second Test"} />
+                        >
+                            <title>Test</title>
+                        </Helmet>
+                        <Helmet>
+                            <title>Second Test</title>
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -146,9 +168,11 @@ describe("Helmet", () => {
                 const dollarTitle = "te$t te$$t te$$$t te$$$$t";
 
                 ReactDOM.render(
-                    <Helmet title={dollarTitle}
-                            titleTemplate={"This is a %s"}
-                    />,
+                    <Helmet
+                        titleTemplate={"This is a %s"}
+                    >
+                        <title>{dollarTitle}</title>
+                    </Helmet>,
                     container
                 );
 
@@ -159,9 +183,9 @@ describe("Helmet", () => {
                 const chineseTitle = "膣膗 鍆錌雔";
 
                 ReactDOM.render(
-                    <div>
-                        <Helmet title={chineseTitle} />
-                    </div>,
+                    <Helmet>
+                        <title>{chineseTitle}</title>
+                    </Helmet>,
                     container
                 );
 
@@ -172,9 +196,10 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <Helmet
                         defaultTitle={"Fallback"}
-                        title={"Test Title with itemProp"}
                         titleAttributes={{itemprop: "name"}}
-                    />,
+                    >
+                        <title>Test Title with itemProp</title>
+                    </Helmet>,
                     container
                 );
 

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -24,7 +24,7 @@ describe("Helmet - Declarative API", () => {
 
     describe("api", () => {
         describe("title", () => {
-            it("can update page title", () => {
+            it("will update page title", () => {
                 ReactDOM.render(
                     <Helmet
                         defaultTitle={"Fallback"}
@@ -37,7 +37,7 @@ describe("Helmet - Declarative API", () => {
                 expect(document.title).to.equal("Test Title");
             });
 
-            it("can update page title with multiple children", () => {
+            it("will update page title with multiple children", () => {
                 ReactDOM.render(
                     <div>
                         <Helmet>

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -213,11 +213,9 @@ describe("Helmet", () => {
         describe("title attributes", () => {
             it("update title attributes", () => {
                 ReactDOM.render(
-                    <Helmet
-                        titleAttributes={{
-                            itemprop: "name"
-                        }}
-                    />,
+                    <Helmet>
+                        <title itemProp="name"></title>
+                    </Helmet>,
                     container
                 );
 
@@ -230,17 +228,12 @@ describe("Helmet", () => {
             it("set attributes based on the deepest nested component", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet
-                            titleAttributes={{
-                                "lang": "en",
-                                "hidden": undefined
-                            }}
-                        />
-                        <Helmet
-                            titleAttributes={{
-                                "lang": "ja"
-                            }}
-                        />
+                        <Helmet>
+                            <title lang="en" hidden></title>
+                        </Helmet>
+                        <Helmet>
+                            <title lang="ja"></title>
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -254,11 +247,9 @@ describe("Helmet", () => {
 
             it("handle valueless attributes", () => {
                 ReactDOM.render(
-                    <Helmet
-                        titleAttributes={{
-                            "hidden": undefined
-                        }}
-                    />,
+                    <Helmet>
+                        <title hidden></title>
+                    </Helmet>,
                     container
                 );
 
@@ -270,12 +261,9 @@ describe("Helmet", () => {
 
             it("clears title attributes that are handled within helmet", () => {
                 ReactDOM.render(
-                    <Helmet
-                        titleAttributes={{
-                            "lang": "en",
-                            "hidden": undefined
-                        }}
-                    />,
+                    <Helmet>
+                        <title lang="en" hidden></title>
+                    </Helmet>,
                     container
                 );
 

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -1,0 +1,2436 @@
+/* eslint max-nested-callbacks: [1, 5] */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import ReactServer from "react-dom/server";
+import Helmet from "../Helmet";
+
+const HELMET_ATTRIBUTE = "data-react-helmet";
+
+describe("Helmet", () => {
+    let headElement;
+
+    const container = document.createElement("div");
+
+    beforeEach(() => {
+        headElement = headElement || document.head || document.querySelector("head");
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(container);
+    });
+
+    describe("api", () => {
+        describe("title", () => {
+            it("can update page title", () => {
+                ReactDOM.render(
+                    <Helmet
+                        defaultTitle={"Fallback"}
+                        title={"Test Title"}
+                    />,
+                    container
+                );
+
+                expect(document.title).to.equal("Test Title");
+            });
+
+            it("can update page title with multiple children", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={"Test Title"} />
+                        <Helmet title={"Child One Title"} />
+                        <Helmet title={"Child Two Title"} />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal("Child Two Title");
+            });
+
+            it("will set title based on deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={"Main Title"} />
+                        <Helmet title={"Nested Title"} />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal("Nested Title");
+            });
+
+            it("will set title using deepest nested component with a defined title", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={"Main Title"} />
+                        <Helmet />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal("Main Title");
+            });
+
+            it("will use defaultTitle if no title is defined", () => {
+                ReactDOM.render(
+                    <Helmet
+                        defaultTitle={"Fallback"}
+                        title={""}
+                        titleTemplate={"This is a %s of the titleTemplate feature"}
+                    />,
+                    container
+                );
+
+                expect(document.title).to.equal("Fallback");
+            });
+
+            it("will use a titleTemplate if defined", () => {
+                ReactDOM.render(
+                    <Helmet
+                        defaultTitle={"Fallback"}
+                        title={"Test"}
+                        titleTemplate={"This is a %s of the titleTemplate feature"}
+                    />,
+                    container
+                );
+
+                expect(document.title).to.equal("This is a Test of the titleTemplate feature");
+            });
+
+            it("will replace multiple title strings in titleTemplate", () => {
+                ReactDOM.render(
+                    <Helmet
+                        title={"Test"}
+                        titleTemplate={"This is a %s of the titleTemplate feature. Another %s."}
+                    />,
+                    container
+                );
+
+                expect(document.title).to.equal("This is a Test of the titleTemplate feature. Another Test.");
+            });
+
+            it("will use a titleTemplate based on deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            title={"Test"}
+                            titleTemplate={"This is a %s of the titleTemplate feature"}
+                        />
+                        <Helmet
+                            title={"Second Test"}
+                            titleTemplate={"A %s using nested titleTemplate attributes"}
+                        />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal("A Second Test using nested titleTemplate attributes");
+            });
+
+            it("will merge deepest component title with nearest upstream titleTemplate", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            title={"Test"}
+                            titleTemplate={"This is a %s of the titleTemplate feature"}
+                        />
+                        <Helmet title={"Second Test"} />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal("This is a Second Test of the titleTemplate feature");
+            });
+
+            it("will render dollar characters in a title correctly when titleTemplate present", () => {
+                const dollarTitle = "te$t te$$t te$$$t te$$$$t";
+
+                ReactDOM.render(
+                    <Helmet title={dollarTitle}
+                            titleTemplate={"This is a %s"}
+                    />,
+                    container
+                );
+
+                expect(document.title).to.equal("This is a te$t te$$t te$$$t te$$$$t");
+            });
+
+            it("will not encode all characters with HTML character entity equivalents", () => {
+                const chineseTitle = "膣膗 鍆錌雔";
+
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={chineseTitle} />
+                    </div>,
+                    container
+                );
+
+                expect(document.title).to.equal(chineseTitle);
+            });
+
+            it("page tite with prop itemprop", () => {
+                ReactDOM.render(
+                    <Helmet
+                        defaultTitle={"Fallback"}
+                        title={"Test Title with itemProp"}
+                        titleAttributes={{itemprop: "name"}}
+                    />,
+                    container
+                );
+
+                const titleTag = document.getElementsByTagName("title")[0];
+                expect(document.title).to.equal("Test Title with itemProp");
+                expect(titleTag.getAttribute("itemprop")).to.equal("name");
+            });
+        });
+
+        describe("title attributes", () => {
+            it("update title attributes", () => {
+                ReactDOM.render(
+                    <Helmet
+                        titleAttributes={{
+                            itemprop: "name"
+                        }}
+                    />,
+                    container
+                );
+
+                const titleTag = document.getElementsByTagName("title")[0];
+
+                expect(titleTag.getAttribute("itemprop")).to.equal("name");
+                expect(titleTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("itemprop");
+            });
+
+            it("set attributes based on the deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            titleAttributes={{
+                                "lang": "en",
+                                "hidden": undefined
+                            }}
+                        />
+                        <Helmet
+                            titleAttributes={{
+                                "lang": "ja"
+                            }}
+                        />
+                    </div>,
+                    container
+                );
+
+                const titleTag = document.getElementsByTagName("title")[0];
+
+                expect(titleTag.getAttribute("lang")).to.equal("ja");
+                expect(titleTag.getAttribute("hidden")).to.equal("");
+                expect(titleTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("lang,hidden");
+            });
+
+            it("handle valueless attributes", () => {
+                ReactDOM.render(
+                    <Helmet
+                        titleAttributes={{
+                            "hidden": undefined
+                        }}
+                    />,
+                    container
+                );
+
+                const titleTag = document.getElementsByTagName("title")[0];
+
+                expect(titleTag.getAttribute("hidden")).to.equal("");
+                expect(titleTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("hidden");
+            });
+
+            it("clears title attributes that are handled within helmet", () => {
+                ReactDOM.render(
+                    <Helmet
+                        titleAttributes={{
+                            "lang": "en",
+                            "hidden": undefined
+                        }}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                const titleTag = document.getElementsByTagName("title")[0];
+
+                expect(titleTag.getAttribute("lang")).to.be.null;
+                expect(titleTag.getAttribute("hidden")).to.be.null;
+                expect(titleTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
+            });
+        });
+
+        describe("html attributes", () => {
+            it("update html attributes", () => {
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "class": "myClassName",
+                            "lang": "en"
+                        }}
+                    />,
+                    container
+                );
+
+                const htmlTag = document.getElementsByTagName("html")[0];
+
+                expect(htmlTag.getAttribute("class")).to.equal("myClassName");
+                expect(htmlTag.getAttribute("lang")).to.equal("en");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("class,lang");
+            });
+
+            it("set attributes based on the deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            htmlAttributes={{
+                                "lang": "en"
+                            }}
+                        />
+                        <Helmet
+                            htmlAttributes={{
+                                "lang": "ja"
+                            }}
+                        />
+                    </div>,
+                    container
+                );
+
+                const htmlTag = document.getElementsByTagName("html")[0];
+
+                expect(htmlTag.getAttribute("lang")).to.equal("ja");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("lang");
+            });
+
+            it("handle valueless attributes", () => {
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "amp": undefined
+                        }}
+                    />,
+                    container
+                );
+
+                const htmlTag = document.getElementsByTagName("html")[0];
+
+                expect(htmlTag.getAttribute("amp")).to.equal("");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("amp");
+            });
+
+            it("clears html attributes that are handled within helmet", () => {
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "lang": "en",
+                            "amp": undefined
+                        }}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                const htmlTag = document.getElementsByTagName("html")[0];
+
+                expect(htmlTag.getAttribute("lang")).to.be.null;
+                expect(htmlTag.getAttribute("amp")).to.be.null;
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
+            });
+
+            it("updates with multiple additions and removals - overwrite and new", () => {
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "lang": "en",
+                            "amp": undefined
+                        }}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "lang": "ja",
+                            "id": "html-tag",
+                            "title": "html tag"
+                        }}
+                    />,
+                    container
+                );
+
+                const htmlTag = document.getElementsByTagName("html")[0];
+
+                expect(htmlTag.getAttribute("amp")).to.equal(null);
+                expect(htmlTag.getAttribute("lang")).to.equal("ja");
+                expect(htmlTag.getAttribute("id")).to.equal("html-tag");
+                expect(htmlTag.getAttribute("title")).to.equal("html tag");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("lang,amp,id,title");
+            });
+
+            it("updates with multiple additions and removals - all new", () => {
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "lang": "en",
+                            "amp": undefined
+                        }}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet
+                        htmlAttributes={{
+                            "id": "html-tag",
+                            "title": "html tag"
+                        }}
+                    />,
+                    container
+                );
+
+                const htmlTag = document.getElementsByTagName("html")[0];
+
+                expect(htmlTag.getAttribute("amp")).to.equal(null);
+                expect(htmlTag.getAttribute("lang")).to.equal(null);
+                expect(htmlTag.getAttribute("id")).to.equal("html-tag");
+                expect(htmlTag.getAttribute("title")).to.equal("html tag");
+                expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("lang,amp,id,title");
+            });
+
+            context("initialized outside of helmet", () => {
+                before(() => {
+                    const htmlTag = document.getElementsByTagName("html")[0];
+                    htmlTag.setAttribute("test", "test");
+                });
+
+                it("will not be cleared", () => {
+                    ReactDOM.render(
+                        <Helmet />,
+                        container
+                    );
+
+                    const htmlTag = document.getElementsByTagName("html")[0];
+
+                    expect(htmlTag.getAttribute("test")).to.equal("test");
+                    expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
+                });
+
+                it("will be overwritten if specified in helmet", () => {
+                    ReactDOM.render(
+                        <Helmet
+                            htmlAttributes={{
+                                "test": "helmet-attr"
+                            }}
+                        />,
+                        container
+                    );
+
+                    const htmlTag = document.getElementsByTagName("html")[0];
+
+                    expect(htmlTag.getAttribute("test")).to.equal("helmet-attr");
+                    expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal("test");
+                });
+
+                it("can be cleared once it is managed in helmet", () => {
+                    ReactDOM.render(
+                        <Helmet
+                            htmlAttributes={{
+                                "test": "helmet-attr"
+                            }}
+                        />,
+                        container
+                    );
+
+                    ReactDOM.render(
+                        <Helmet />,
+                        container
+                    );
+
+                    const htmlTag = document.getElementsByTagName("html")[0];
+
+                    expect(htmlTag.getAttribute("test")).to.equal(null);
+                    expect(htmlTag.getAttribute(HELMET_ATTRIBUTE)).to.equal(null);
+                });
+            });
+        });
+
+        describe("onChangeClientState", () => {
+            it("when handling client state change, calls the function with new state, addedTags and removedTags ", () => {
+                const spy = sinon.spy();
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            base={{"href": "http://mysite.com/"}}
+                            link={[{"href": "http://localhost/helmet", "rel": "canonical"}]}
+                            meta={[{"charset": "utf-8"}]}
+                            script={[{"src": "http://localhost/test.js", "type": "text/javascript"}]}
+                            title={"Main Title"}
+                            onChangeClientState={spy}
+                        />
+                    </div>,
+                    container
+                );
+
+                expect(spy.called).to.equal(true);
+                const newState = spy.getCall(0).args[0];
+                const addedTags = spy.getCall(0).args[1];
+                const removedTags = spy.getCall(0).args[2];
+
+                expect(newState).to.contain({title: "Main Title"});
+                expect(newState.baseTag).to.contain({href: "http://mysite.com/"});
+                expect(newState.metaTags).to.contain({"charset": "utf-8"});
+                expect(newState.linkTags).to.contain({"href": "http://localhost/helmet", "rel": "canonical"});
+                expect(newState.scriptTags).to.contain({"src": "http://localhost/test.js", "type": "text/javascript"});
+
+                expect(addedTags).to.have.property("baseTag");
+                expect(addedTags.baseTag).to.have.deep.property("[0]");
+                expect(addedTags.baseTag[0].outerHTML).to.equal(`<base href="http://mysite.com/" data-react-helmet="true">`);
+
+                expect(addedTags).to.have.property("metaTags");
+                expect(addedTags.metaTags).to.have.deep.property("[0]");
+                expect(addedTags.metaTags[0].outerHTML).to.equal(`<meta charset="utf-8" data-react-helmet="true">`);
+
+                expect(addedTags).to.have.property("linkTags");
+                expect(addedTags.linkTags).to.have.deep.property("[0]");
+                expect(addedTags.linkTags[0].outerHTML).to.equal(`<link href="http://localhost/helmet" rel="canonical" data-react-helmet="true">`);
+
+                expect(addedTags).to.have.property("scriptTags");
+                expect(addedTags.scriptTags).to.have.deep.property("[0]");
+                expect(addedTags.scriptTags[0].outerHTML).to.equal(`<script src="http://localhost/test.js" type="text/javascript" data-react-helmet="true"></script>`);
+
+                expect(removedTags).to.be.empty;
+            });
+
+            it("calls the deepest defined callback with the deepest state", () => {
+                const spy = sinon.spy();
+                ReactDOM.render(
+                    <div>
+                        <Helmet title={"Main Title"} onChangeClientState={spy} />
+                        <Helmet title={"Deeper Title"} />
+                    </div>,
+                    container
+                );
+
+                expect(spy.callCount).to.equal(2);
+                expect(spy.getCall(0).args[0]).to.contain({title: "Main Title"});
+                expect(spy.getCall(1).args[0]).to.contain({title: "Deeper Title"});
+            });
+        });
+
+        describe("base tag", () => {
+            it("can update base tag", () => {
+                ReactDOM.render(
+                    <Helmet
+                        base={{"href": "http://mysite.com/"}}
+                    />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`base[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+
+                const filteredTags = [].slice.call(existingTags).filter((tag) => {
+                    return tag.getAttribute("href") === "http://mysite.com/";
+                });
+
+                expect(filteredTags.length).to.equal(1);
+            });
+
+            it("will clear the base tag if one is not specified", () => {
+                ReactDOM.render(
+                    <Helmet
+                        base={{"href": "http://mysite.com/"}}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`base[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("tags without 'href' will not be accepted", () => {
+                ReactDOM.render(
+                    <Helmet
+                        base={{"property": "won't work"}}
+                    />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`base[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("will set base tag based on deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            base={{"href": "http://mysite.com/"}}
+                        />
+                        <Helmet
+                            base={{"href": "http://mysite.com/public"}}
+                        />
+                    </div>,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`base[${HELMET_ATTRIBUTE}]`);
+                const firstTag = Array.prototype.slice.call(existingTags)[0];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.equal(1);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("href")).to.equal("http://mysite.com/public");
+                expect(firstTag.outerHTML).to.equal(`<base href="http://mysite.com/public" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("won't render tag when primary attribute is null", () => {
+                ReactDOM.render(
+                    <Helmet
+                        base={{"href": undefined}}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`base[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                expect(existingTags).to.be.empty;
+            });
+        });
+
+        describe("meta tags", () => {
+            it("can update meta tags", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={[
+                            {"charset": "utf-8"},
+                            {"name": "description", "content": "Test description"},
+                            {"http-equiv": "content-type", "content": "text/html"},
+                            {"property": "og:type", "content": "article"},
+                            {"itemprop": "name", "content": "Test name itemprop"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+
+                expect(existingTags).to.not.equal(undefined);
+
+                const filteredTags = [].slice.call(existingTags).filter((tag) => {
+                    return tag.getAttribute("charset") === "utf-8" ||
+                        (tag.getAttribute("name") === "description" && tag.getAttribute("content") === "Test description") ||
+                        (tag.getAttribute("http-equiv") === "content-type" && tag.getAttribute("content") === "text/html") ||
+                        (tag.getAttribute("itemprop") === "name" && tag.getAttribute("content") === "Test name itemprop");
+                });
+
+                expect(filteredTags.length).to.be.at.least(4);
+            });
+
+            it("will clear all meta tags if none are specified", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={[{"name": "description", "content": "Test description"}]}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("tags without 'name', 'http-equiv', 'property', 'charset', or 'itemprop' will not be accepted", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={[{"href": "won't work"}]}
+                    />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("will set meta tags based on deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            meta={[
+                                {"charset": "utf-8"},
+                                {"name": "description", "content": "Test description"}
+                            ]}
+                        />
+                        <Helmet
+                            meta={[
+                                {"name": "description", "content": "Inner description"},
+                                {"name": "keywords", "content": "test,meta,tags"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+                const thirdTag = existingTags[2];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.equal(3);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("charset")).to.equal("utf-8");
+                expect(firstTag.outerHTML).to.equal(`<meta charset="utf-8" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("name")).to.equal("description");
+                expect(secondTag.getAttribute("content")).to.equal("Inner description");
+                expect(secondTag.outerHTML).to.equal(`<meta name="description" content="Inner description" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[2]")
+                    .that.is.an.instanceof(Element);
+                expect(thirdTag).to.have.property("getAttribute");
+                expect(thirdTag.getAttribute("name")).to.equal("keywords");
+                expect(thirdTag.getAttribute("content")).to.equal("test,meta,tags");
+                expect(thirdTag.outerHTML).to.equal(`<meta name="keywords" content="test,meta,tags" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("will allow duplicate meta tags if specified in the same component", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={[
+                            {"name": "description", "content": "Test description"},
+                            {"name": "description", "content": "Duplicate description"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.equal(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("name")).to.equal("description");
+                expect(firstTag.getAttribute("content")).to.equal("Test description");
+                expect(firstTag.outerHTML).to.equal(`<meta name="description" content="Test description" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("name")).to.equal("description");
+                expect(secondTag.getAttribute("content")).to.equal("Duplicate description");
+                expect(secondTag.outerHTML).to.equal(`<meta name="description" content="Duplicate description" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("will override duplicate meta tags with single meta tag in a nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            meta={[
+                                {"name": "description", "content": "Test description"},
+                                {"name": "description", "content": "Duplicate description"}
+                            ]}
+                        />
+                        <Helmet
+                            meta={[
+                                {"name": "description", "content": "Inner description"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.equal(1);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("name")).to.equal("description");
+                expect(firstTag.getAttribute("content")).to.equal("Inner description");
+                expect(firstTag.outerHTML).to.equal(`<meta name="description" content="Inner description" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("will override single meta tag with duplicate meta tags in a nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            meta={[
+                                {"name": "description", "content": "Test description"}
+                            ]}
+                        />
+                        <Helmet
+                            meta={[
+                                {"name": "description", "content": "Inner description"},
+                                {"name": "description", "content": "Inner duplicate description"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.equal(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("name")).to.equal("description");
+                expect(firstTag.getAttribute("content")).to.equal("Inner description");
+                expect(firstTag.outerHTML).to.equal(`<meta name="description" content="Inner description" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("name")).to.equal("description");
+                expect(secondTag.getAttribute("content")).to.equal("Inner duplicate description");
+                expect(secondTag.outerHTML).to.equal(`<meta name="description" content="Inner duplicate description" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("won't render tag when primary attribute is null", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={[
+                            {"name": undefined, "content": "Inner duplicate description"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                expect(existingTags).to.be.empty;
+            });
+
+            it("fails gracefully when meta is wrong shape", () => {
+                ReactDOM.render(
+                    <Helmet
+                        meta={{"name": "title", "content": "some title"}}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                expect(existingTags).to.be.empty;
+            });
+        });
+
+        describe("link tags", () => {
+            it("can update link tags", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"href": "http://localhost/helmet", "rel": "canonical"},
+                            {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+
+                expect(existingTags).to.not.equal(undefined);
+
+                const filteredTags = [].slice.call(existingTags).filter((tag) => {
+                    return (tag.getAttribute("href") === "http://localhost/style.css" && tag.getAttribute("rel") === "stylesheet" && tag.getAttribute("type") === "text/css") ||
+                        (tag.getAttribute("href") === "http://localhost/helmet" && tag.getAttribute("rel") === "canonical");
+                });
+
+                expect(filteredTags.length).to.be.at.least(2);
+            });
+
+            it("will clear all link tags if none are specified", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"href": "http://localhost/helmet", "rel": "canonical"}
+                        ]}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("tags without 'href' or 'rel' will not be accepted, even if they are valid for other tags", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[{"http-equiv": "won't work"}]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("tags 'rel' and 'href' will properly use 'rel' as the primary identification for this tag, regardless of ordering", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            link={[{"href": "http://localhost/helmet", "rel": "canonical"}]}
+                        />
+                        <Helmet
+                            link={[{"rel": "canonical", "href": "http://localhost/helmet/new"}]}
+                        />
+                        <Helmet
+                            link={[{"href": "http://localhost/helmet/newest", "rel": "canonical"}]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.equal(1);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("rel")).to.equal("canonical");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/helmet/newest");
+                expect(firstTag.outerHTML).to.equal(`<link href="http://localhost/helmet/newest" rel="canonical" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("tags with rel='stylesheet' will use the href as the primary identification of the tag, regardless of ordering", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            link={[
+                                {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css", "media": "all"}
+                            ]}
+                        />
+                        <Helmet
+                            link={[
+                                {"rel": "stylesheet", "href": "http://localhost/inner.css", "type": "text/css", "media": "all"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.equal(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/style.css");
+                expect(firstTag.getAttribute("rel")).to.equal("stylesheet");
+                expect(firstTag.getAttribute("type")).to.equal("text/css");
+                expect(firstTag.getAttribute("media")).to.equal("all");
+                expect(firstTag.outerHTML).to.equal(`<link href="http://localhost/style.css" rel="stylesheet" type="text/css" media="all" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("rel")).to.equal("stylesheet");
+                expect(secondTag.getAttribute("href")).to.equal("http://localhost/inner.css");
+                expect(secondTag.getAttribute("type")).to.equal("text/css");
+                expect(secondTag.getAttribute("media")).to.equal("all");
+                expect(secondTag.outerHTML).to.equal(`<link rel="stylesheet" href="http://localhost/inner.css" type="text/css" media="all" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("will set link tags based on deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            link={[
+                                {"rel": "canonical", "href": "http://localhost/helmet"},
+                                {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css", "media": "all"}
+                            ]}
+                        />
+                        <Helmet
+                            link={[
+                                {"rel": "canonical", "href": "http://localhost/helmet/innercomponent"},
+                                {"href": "http://localhost/inner.css", "rel": "stylesheet", "type": "text/css", "media": "all"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+                const thirdTag = existingTags[2];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.at.least(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/style.css");
+                expect(firstTag.getAttribute("rel")).to.equal("stylesheet");
+                expect(firstTag.getAttribute("type")).to.equal("text/css");
+                expect(firstTag.getAttribute("media")).to.equal("all");
+                expect(firstTag.outerHTML).to.equal(`<link href="http://localhost/style.css" rel="stylesheet" type="text/css" media="all" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("href")).to.equal("http://localhost/helmet/innercomponent");
+                expect(secondTag.getAttribute("rel")).to.equal("canonical");
+                expect(secondTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/innercomponent" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[2]")
+                    .that.is.an.instanceof(Element);
+                expect(thirdTag).to.have.property("getAttribute");
+                expect(thirdTag.getAttribute("href")).to.equal("http://localhost/inner.css");
+                expect(thirdTag.getAttribute("rel")).to.equal("stylesheet");
+                expect(thirdTag.getAttribute("type")).to.equal("text/css");
+                expect(thirdTag.getAttribute("media")).to.equal("all");
+                expect(thirdTag.outerHTML).to.equal(`<link href="http://localhost/inner.css" rel="stylesheet" type="text/css" media="all" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("will allow duplicate link tags if specified in the same component", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"rel": "canonical", "href": "http://localhost/helmet"},
+                            {"rel": "canonical", "href": "http://localhost/helmet/component"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.at.least(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("rel")).to.equal("canonical");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/helmet");
+                expect(firstTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("rel")).to.equal("canonical");
+                expect(secondTag.getAttribute("href")).to.equal("http://localhost/helmet/component");
+                expect(secondTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/component" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("will override duplicate link tags with a single link tag in a nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            link={[
+                                {"rel": "canonical", "href": "http://localhost/helmet"},
+                                {"rel": "canonical", "href": "http://localhost/helmet/component"}
+                            ]}
+                        />
+                        <Helmet
+                            link={[
+                                {"rel": "canonical", "href": "http://localhost/helmet/innercomponent"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.equal(1);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("rel")).to.equal("canonical");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/helmet/innercomponent");
+                expect(firstTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/innercomponent" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("will override single link tag with duplicate link tags in a nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            link={[
+                                {"rel": "canonical", "href": "http://localhost/helmet"}
+                            ]}
+                        />
+                        <Helmet
+                            link={[
+                                {"rel": "canonical", "href": "http://localhost/helmet/component"},
+                                {"rel": "canonical", "href": "http://localhost/helmet/innercomponent"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.equal(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("rel")).to.equal("canonical");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/helmet/component");
+                expect(firstTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/component" ${HELMET_ATTRIBUTE}="true">`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("rel")).to.equal("canonical");
+                expect(secondTag.getAttribute("href")).to.equal("http://localhost/helmet/innercomponent");
+                expect(secondTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/innercomponent" ${HELMET_ATTRIBUTE}="true">`);
+            });
+
+            it("won't render tag when primary attribute is null", () => {
+                ReactDOM.render(
+                    <Helmet
+                        link={[
+                            {"rel": "icon", "sizes": "192x192", "href": null},
+                            {"rel": "canonical", "href": "http://localhost/helmet/component"}
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.be.equal(1);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("rel")).to.equal("canonical");
+                expect(firstTag.getAttribute("href")).to.equal("http://localhost/helmet/component");
+                expect(firstTag.outerHTML).to.equal(`<link rel="canonical" href="http://localhost/helmet/component" ${HELMET_ATTRIBUTE}="true">`);
+            });
+        });
+
+        describe("script tags", () => {
+            it("can update script tags", () => {
+                const scriptInnerHTML = `
+                  {
+                    "@context": "http://schema.org",
+                    "@type": "NewsArticle",
+                    "url": "http://localhost/helmet"
+                  }
+                `;
+                ReactDOM.render(
+                    <Helmet
+                        script={[
+                            {"src": "http://localhost/test.js", "type": "text/javascript"},
+                            {"src": "http://localhost/test2.js", "type": "text/javascript"},
+                            {
+                                type: "application/ld+json",
+                                innerHTML: scriptInnerHTML
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const existingTags = headElement.getElementsByTagName("script");
+
+                expect(existingTags).to.not.equal(undefined);
+
+                const filteredTags = [].slice.call(existingTags).filter((tag) => {
+                    return (tag.getAttribute("src") === "http://localhost/test.js" && tag.getAttribute("type") === "text/javascript") ||
+                        (tag.getAttribute("src") === "http://localhost/test2.js" && tag.getAttribute("type") === "text/javascript") ||
+                        (tag.getAttribute("type") === "application/ld+json" && tag.innerHTML === scriptInnerHTML);
+                });
+
+                expect(filteredTags.length).to.be.at.least(3);
+            });
+
+            it("will clear all scripts tags if none are specified", () => {
+                ReactDOM.render(
+                    <Helmet
+                        script={[
+                            {"src": "http://localhost/test.js", "type": "text/javascript"}
+                        ]}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`script[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("tags without 'src' will not be accepted", () => {
+                ReactDOM.render(
+                    <Helmet
+                        script={[{"property": "won't work"}]}
+                    />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`script[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("will set script tags based on deepest nested component", () => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            script={[
+                                {"src": "http://localhost/test.js", "type": "text/javascript"}
+                            ]}
+                        />
+                        <Helmet
+                            script={[
+                                {"src": "http://localhost/test2.js", "type": "text/javascript"}
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`script[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                const firstTag = existingTags[0];
+                const secondTag = existingTags[1];
+
+                expect(existingTags).to.not.equal(undefined);
+
+                expect(existingTags.length).to.be.at.least(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("src")).to.equal("http://localhost/test.js");
+                expect(firstTag.getAttribute("type")).to.equal("text/javascript");
+                expect(firstTag.outerHTML).to.equal(`<script src="http://localhost/test.js" type="text/javascript" ${HELMET_ATTRIBUTE}="true"></script>`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag).to.have.property("getAttribute");
+                expect(secondTag.getAttribute("src")).to.equal("http://localhost/test2.js");
+                expect(secondTag.getAttribute("type")).to.equal("text/javascript");
+                expect(secondTag.outerHTML).to.equal(`<script src="http://localhost/test2.js" type="text/javascript" ${HELMET_ATTRIBUTE}="true"></script>`);
+            });
+
+
+            it("sets undefined attribute values to empty strings", () => {
+                ReactDOM.render(
+                    <Helmet
+                        script={[
+                            {
+                                src: "foo.js",
+                                async: undefined
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const existingTag = headElement.querySelector(`script[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTag).to.not.equal(undefined);
+                expect(existingTag.outerHTML)
+                    .to.be.a("string")
+                    .that.equals(`<script src="foo.js" async="" ${HELMET_ATTRIBUTE}="true"></script>`);
+            });
+
+            it("won't render tag when primary attribute (src) is null", () => {
+                ReactDOM.render(
+                    <Helmet
+                        script={[
+                            {
+                                src: undefined,
+                                type: "text/javascript"
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`script[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                expect(existingTags).to.be.empty;
+            });
+
+            it("won't render tag when primary attribute (innerHTML) is null", () => {
+                ReactDOM.render(
+                    <Helmet
+                        script={[
+                            {
+                                innerHTML: undefined
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`script[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                expect(existingTags).to.be.empty;
+            });
+        });
+
+        describe("noscript tags", () => {
+            it("can update noscript tags", () => {
+                const noscriptInnerHTML = `<link rel="stylesheet" type="text/css" href="foo.css" />`;
+                ReactDOM.render(
+                    <Helmet noscript={[{id: "bar", innerHTML: noscriptInnerHTML}]} />,
+                    container
+                );
+
+                const existingTags = headElement.getElementsByTagName("noscript");
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(1);
+                expect(existingTags[0].innerHTML === noscriptInnerHTML && existingTags[0].id === "bar");
+            });
+
+            it("will clear all noscripts tags if none are specified", () => {
+                ReactDOM.render(<Helmet noscript={[{id: "bar"}]} />, container);
+
+                ReactDOM.render(<Helmet />, container);
+
+                const existingTags = headElement.querySelectorAll(`script[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("tags without 'innerHTML' will not be accepted", () => {
+                ReactDOM.render(
+                    <Helmet noscript={[{"property": "won't work"}]} />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`noscript[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("won't render tag when primary attribute is null", () => {
+                ReactDOM.render(
+                    <Helmet
+                        noscript={[
+                            {
+                                innerHTML: undefined
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`noscript[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                expect(existingTags).to.be.empty;
+            });
+        });
+
+        describe("style tags", () => {
+            it("can update style tags", () => {
+                const cssText1 = `
+                    body {
+                        background-color: green;
+                    }
+                `;
+                const cssText2 = `
+                    p {
+                        font-size: 12px;
+                    }
+                `;
+                ReactDOM.render(
+                    <Helmet
+                        style={[
+                            {
+                                type: "text/css",
+                                cssText: cssText1
+                            },
+                            {
+                                cssText: cssText2
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`style[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+
+                const [
+                    firstTag,
+                    secondTag
+                ] = existingTags;
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.be.equal(2);
+
+                expect(existingTags)
+                    .to.have.deep.property("[0]")
+                    .that.is.an.instanceof(Element);
+                expect(firstTag).to.have.property("getAttribute");
+                expect(firstTag.getAttribute("type")).to.equal("text/css");
+                expect(firstTag.innerHTML).to.equal(cssText1);
+                expect(firstTag.outerHTML).to.equal(`<style type="text/css" ${HELMET_ATTRIBUTE}="true">${cssText1}</style>`);
+
+                expect(existingTags)
+                    .to.have.deep.property("[1]")
+                    .that.is.an.instanceof(Element);
+                expect(secondTag.innerHTML).to.equal(cssText2);
+                expect(secondTag.outerHTML).to.equal(`<style ${HELMET_ATTRIBUTE}="true">${cssText2}</style>`);
+            });
+
+            it("will clear all style tags if none are specified", () => {
+                const cssText = `
+                    body {
+                        background-color: green;
+                    }
+                `;
+                ReactDOM.render(
+                    <Helmet
+                        style={[
+                            {
+                                type: "text/css",
+                                cssText
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                ReactDOM.render(
+                    <Helmet />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`style[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("tags without 'cssText' will not be accepted", () => {
+                ReactDOM.render(
+                    <Helmet
+                        style={[{"property": "won't work"}]}
+                    />,
+                    container
+                );
+
+                const existingTags = headElement.querySelectorAll(`style[${HELMET_ATTRIBUTE}]`);
+
+                expect(existingTags).to.not.equal(undefined);
+                expect(existingTags.length).to.equal(0);
+            });
+
+            it("won't render tag when primary attribute is null", () => {
+                ReactDOM.render(
+                    <Helmet
+                        style={[
+                            {
+                                cssText: undefined
+                            }
+                        ]}
+                    />,
+                    container
+                );
+
+                const tagNodes = headElement.querySelectorAll(`style[${HELMET_ATTRIBUTE}]`);
+                const existingTags = Array.prototype.slice.call(tagNodes);
+                expect(existingTags).to.be.empty;
+            });
+        });
+    });
+
+    describe("server", () => {
+        const stringifiedHtmlAttributes = `lang="ga" class="myClassName"`;
+        const stringifiedTitle = `<title ${HELMET_ATTRIBUTE}="true">Dangerous &lt;script&gt; include</title>`;
+        const stringifiedTitleWithItemprop = `<title ${HELMET_ATTRIBUTE}="true" itemprop="name">Title with Itemprop</title>`;
+        const stringifiedBaseTag = `<base ${HELMET_ATTRIBUTE}="true" target="_blank" href="http://localhost/"/>`;
+
+        const stringifiedMetaTags = [
+            `<meta ${HELMET_ATTRIBUTE}="true" charset="utf-8"/>`,
+            `<meta ${HELMET_ATTRIBUTE}="true" name="description" content="Test description &amp; encoding of special characters like &#x27; &quot; &gt; &lt; \`"/>`,
+            `<meta ${HELMET_ATTRIBUTE}="true" http-equiv="content-type" content="text/html"/>`,
+            `<meta ${HELMET_ATTRIBUTE}="true" property="og:type" content="article"/>`,
+            `<meta ${HELMET_ATTRIBUTE}="true" itemprop="name" content="Test name itemprop"/>`
+        ].join("");
+
+        const stringifiedLinkTags = [
+            `<link ${HELMET_ATTRIBUTE}="true" href="http://localhost/helmet" rel="canonical"/>`,
+            `<link ${HELMET_ATTRIBUTE}="true" href="http://localhost/style.css" rel="stylesheet" type="text/css"/>`
+        ].join("");
+
+        const stringifiedScriptTags = [
+            `<script ${HELMET_ATTRIBUTE}="true" src="http://localhost/test.js" type="text/javascript"></script>`,
+            `<script ${HELMET_ATTRIBUTE}="true" src="http://localhost/test2.js" type="text/javascript"></script>`
+        ].join("");
+
+        const stringifiedNoscriptTags = [
+            `<noscript ${HELMET_ATTRIBUTE}="true" id="foo"><link rel="stylesheet" type="text/css" href="/style.css" /></noscript>`,
+            `<noscript ${HELMET_ATTRIBUTE}="true" id="bar"><link rel="stylesheet" type="text/css" href="/style2.css" /></noscript>`
+        ].join("");
+
+        const stringifiedStyleTags = [
+            `<style ${HELMET_ATTRIBUTE}="true" type="text/css">body {background-color: green;}</style>`,
+            `<style ${HELMET_ATTRIBUTE}="true" type="text/css">p {font-size: 12px;}</style>`
+        ].join("");
+
+        before(() => {
+            Helmet.canUseDOM = false;
+        });
+
+        it("will html encode title", () => {
+            ReactDOM.render(
+                <Helmet
+                    title="Dangerous <script> include"
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toString");
+
+            expect(head.title.toString()).to.equal(stringifiedTitle);
+        });
+
+        it("will render title as React component", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Dangerous <script> include"}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toComponent");
+
+            const titleComponent = head.title.toComponent();
+
+            expect(titleComponent)
+                .to.be.an("array")
+                .that.has.length.of(1);
+
+            titleComponent.forEach(title => {
+                expect(title)
+                    .to.be.an("object")
+                    .that.contains.property("type", "title");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {titleComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedTitle
+                }</div>`);
+        });
+
+        it("will render title with itemprop name as React component", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Title with Itemprop"}
+                    titleAttributes={{itemprop: "name"}}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toComponent");
+
+            const titleComponent = head.title.toComponent();
+
+            expect(titleComponent)
+                .to.be.an("array")
+                .that.has.length.of(1);
+
+            titleComponent.forEach(title => {
+                expect(title)
+                    .to.be.an("object")
+                    .that.contains.property("type", "title");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {titleComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedTitleWithItemprop
+                }</div>`);
+        });
+
+        it("will render base tag as React component", () => {
+            ReactDOM.render(
+                <Helmet
+                    base={{"target": "_blank", "href": "http://localhost/"}}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.base).to.exist;
+            expect(head.base).to.respondTo("toComponent");
+
+            const baseComponent = head.base.toComponent();
+
+            expect(baseComponent)
+                .to.be.an("array")
+                .that.has.length.of(1);
+
+            baseComponent.forEach(base => {
+                expect(base)
+                    .to.be.an("object")
+                    .that.contains.property("type", "base");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {baseComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedBaseTag
+                }</div>`);
+        });
+
+        it("will render meta tags as React components", () => {
+            ReactDOM.render(
+                <Helmet
+                    meta={[
+                        {"charset": "utf-8"},
+                        {"name": "description", "content": "Test description & encoding of special characters like ' \" > < `"},
+                        {"http-equiv": "content-type", "content": "text/html"},
+                        {"property": "og:type", "content": "article"},
+                        {"itemprop": "name", "content": "Test name itemprop"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.meta).to.exist;
+            expect(head.meta).to.respondTo("toComponent");
+
+            const metaComponent = head.meta.toComponent();
+
+            expect(metaComponent)
+                .to.be.an("array")
+                .that.has.length.of(5);
+
+            metaComponent.forEach(meta => {
+                expect(meta)
+                    .to.be.an("object")
+                    .that.contains.property("type", "meta");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {metaComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedMetaTags
+                }</div>`);
+        });
+
+        it("will render link tags as React components", () => {
+            ReactDOM.render(
+                <Helmet
+                    link={[
+                        {"href": "http://localhost/helmet", "rel": "canonical"},
+                        {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.link).to.exist;
+            expect(head.link).to.respondTo("toComponent");
+
+            const linkComponent = head.link.toComponent();
+
+            expect(linkComponent)
+                .to.be.an("array")
+                .that.has.length.of(2);
+
+            linkComponent.forEach(link => {
+                expect(link)
+                    .to.be.an("object")
+                    .that.contains.property("type", "link");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {linkComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedLinkTags
+                }</div>`);
+        });
+
+        it("will render script tags as React components", () => {
+            ReactDOM.render(
+                <Helmet
+                    script={[
+                        {"src": "http://localhost/test.js", "type": "text/javascript"},
+                        {"src": "http://localhost/test2.js", "type": "text/javascript"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.script).to.exist;
+            expect(head.script).to.respondTo("toComponent");
+
+            const scriptComponent = head.script.toComponent();
+
+            expect(scriptComponent)
+                .to.be.an("array")
+                .that.has.length.of(2);
+
+            scriptComponent.forEach(script => {
+                expect(script)
+                    .to.be.an("object")
+                    .that.contains.property("type", "script");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {scriptComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedScriptTags
+                }</div>`);
+        });
+
+        it("will render noscript tags as React components", () => {
+            ReactDOM.render(
+                <Helmet
+                  noscript={[
+                    {id: "foo", innerHTML: '<link rel="stylesheet" type="text/css" href="/style.css" />'},
+                    {id: "bar", innerHTML: '<link rel="stylesheet" type="text/css" href="/style2.css" />'}
+                  ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.noscript).to.exist;
+            expect(head.noscript).to.respondTo("toComponent");
+
+            const noscriptComponent = head.noscript.toComponent();
+
+            expect(noscriptComponent)
+                .to.be.an("array")
+                .that.has.length.of(2);
+
+            noscriptComponent.forEach(noscript => {
+                expect(noscript)
+                    .to.be.an("object")
+                    .that.contains.property("type", "noscript");
+            });
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {noscriptComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedNoscriptTags
+                }</div>`);
+        });
+
+        it("will render style tags as React components", () => {
+            ReactDOM.render(
+                <Helmet
+                    style={[
+                        {
+                            "type": "text/css",
+                            "cssText": `body {background-color: green;}`
+                        },
+                        {
+                            "type": "text/css",
+                            "cssText": `p {font-size: 12px;}`
+                        }
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.style).to.exist;
+            expect(head.style).to.respondTo("toComponent");
+
+            const styleComponent = head.style.toComponent();
+
+            expect(styleComponent)
+                .to.be.an("array")
+                .that.has.length.of(2);
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {styleComponent}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div>${
+                    stringifiedStyleTags
+                }</div>`);
+        });
+
+        it("will render title tag as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Dangerous <script> include"}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toString");
+
+            expect(head.title.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedTitle);
+        });
+
+        it("will render title with itemprop name as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Title with Itemprop"}
+                    titleAttributes={{itemprop: "name"}}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toString");
+
+            const titleString = head.title.toString();
+            expect(titleString)
+                .to.be.a("string")
+                .that.equals(stringifiedTitleWithItemprop);
+        });
+
+        it("will render base tags as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    base={{"target": "_blank", "href": "http://localhost/"}}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.base).to.exist;
+            expect(head.base).to.respondTo("toString");
+
+            expect(head.base.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedBaseTag);
+        });
+
+        it("will render meta tags as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    meta={[
+                        {"charset": "utf-8"},
+                        {"name": "description", "content": "Test description & encoding of special characters like ' \" > < `"},
+                        {"http-equiv": "content-type", "content": "text/html"},
+                        {"property": "og:type", "content": "article"},
+                        {"itemprop": "name", "content": "Test name itemprop"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.meta).to.exist;
+            expect(head.meta).to.respondTo("toString");
+
+            expect(head.meta.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedMetaTags);
+        });
+
+        it("will render link tags as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    link={[
+                        {"href": "http://localhost/helmet", "rel": "canonical"},
+                        {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.link).to.exist;
+            expect(head.link).to.respondTo("toString");
+
+            expect(head.link.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedLinkTags);
+        });
+
+        it("will render script tags as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    script={[
+                        {"src": "http://localhost/test.js", "type": "text/javascript"},
+                        {"src": "http://localhost/test2.js", "type": "text/javascript"}
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.script).to.exist;
+            expect(head.script).to.respondTo("toString");
+
+            expect(head.script.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedScriptTags);
+        });
+
+        it("will render style tags as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    style={[
+                        {
+                            "type": "text/css",
+                            "cssText": `body {background-color: green;}`
+                        },
+                        {
+                            "type": "text/css",
+                            "cssText": `p {font-size: 12px;}`
+                        }
+                    ]}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.style).to.exist;
+            expect(head.style).to.respondTo("toString");
+
+            expect(head.style.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedStyleTags);
+        });
+
+        it("will render html attributes as component", () => {
+            ReactDOM.render(
+                <Helmet
+                    htmlAttributes={{
+                        lang: "ga",
+                        className: "myClassName"
+                    }}
+                />,
+                container
+            );
+
+            const {htmlAttributes} = Helmet.rewind();
+            const attrs = htmlAttributes.toComponent();
+
+            expect(attrs).to.exist;
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <html lang="en" {...attrs} />
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<html ${stringifiedHtmlAttributes}></html>`);
+        });
+
+        it("will render html attributes as string", () => {
+            ReactDOM.render(
+                <Helmet
+                    htmlAttributes={{
+                        lang: "ga",
+                        class: "myClassName"
+                    }}
+                />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.htmlAttributes).to.exist;
+            expect(head.htmlAttributes).to.respondTo("toString");
+
+            expect(head.htmlAttributes.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedHtmlAttributes);
+        });
+
+        it("will not encode all characters with HTML character entity equivalents", () => {
+            const chineseTitle = "膣膗 鍆錌雔";
+            const stringifiedChineseTitle = `<title ${HELMET_ATTRIBUTE}="true">${chineseTitle}</title>`;
+
+            ReactDOM.render(
+                <div>
+                    <Helmet title={chineseTitle} />
+                </div>,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toString");
+
+            expect(head.title.toString())
+                .to.be.a("string")
+                .that.equals(stringifiedChineseTitle);
+        });
+
+        it("rewind() provides a fallback object for empty Helmet state", () => {
+            ReactDOM.render(
+                <div />,
+                container
+            );
+
+            const head = Helmet.rewind();
+
+            expect(head.htmlAttributes).to.exist;
+            expect(head.htmlAttributes).to.respondTo("toString");
+            expect(head.htmlAttributes.toString()).to.equal("");
+            expect(head.htmlAttributes).to.respondTo("toComponent");
+            expect(head.htmlAttributes.toComponent()).to.be.an("object")
+                .that.is.empty;
+
+            expect(head.title).to.exist;
+            expect(head.title).to.respondTo("toString");
+            expect(head.title.toString()).to.equal(`<title ${HELMET_ATTRIBUTE}="true"></title>`);
+            expect(head.title).to.respondTo("toComponent");
+
+            const markup = ReactServer.renderToStaticMarkup(
+                <div>
+                    {head.title.toComponent()}
+                </div>
+            );
+
+            expect(markup)
+                .to.be.a("string")
+                .that.equals(`<div><title ${HELMET_ATTRIBUTE}="true"></title></div>`);
+
+            expect(head.base).to.exist;
+            expect(head.base).to.respondTo("toString");
+            expect(head.base.toString()).to.equal("");
+            expect(head.base).to.respondTo("toComponent");
+            expect(head.base.toComponent()).to.be.an("array")
+                .that.is.empty;
+
+            expect(head.meta).to.exist;
+            expect(head.meta).to.respondTo("toString");
+            expect(head.meta.toString()).to.equal("");
+            expect(head.meta).to.respondTo("toComponent");
+            expect(head.meta.toComponent()).to.be.an("array")
+                .that.is.empty;
+
+            expect(head.link).to.exist;
+            expect(head.link).to.respondTo("toString");
+            expect(head.link.toString()).to.equal("");
+            expect(head.link).to.respondTo("toComponent");
+            expect(head.link.toComponent()).to.be.an("array")
+                .that.is.empty;
+
+            expect(head.script).to.exist;
+            expect(head.script).to.respondTo("toString");
+            expect(head.script.toString()).to.equal("");
+            expect(head.script).to.respondTo("toComponent");
+            expect(head.script.toComponent()).to.be.an("array")
+                .that.is.empty;
+
+            expect(head.noscript).to.exist;
+            expect(head.noscript).to.respondTo("toString");
+            expect(head.noscript.toString()).to.equal("");
+            expect(head.noscript).to.respondTo("toComponent");
+            expect(head.noscript.toComponent()).to.be.an("array")
+                .that.is.empty;
+
+            expect(head.style).to.exist;
+            expect(head.style).to.respondTo("toString");
+            expect(head.style.toString()).to.equal("");
+            expect(head.style).to.respondTo("toComponent");
+            expect(head.style.toComponent()).to.be.an("array")
+                .that.is.empty;
+        });
+
+        it("does not render undefined attribute values", () => {
+            ReactDOM.render(
+                <Helmet
+                    script={[
+                        {
+                            src: "foo.js",
+                            async: undefined
+                        }
+                    ]}
+                />,
+                container
+            );
+
+            const {script} = Helmet.rewind();
+            const stringifiedScriptTag = script.toString();
+
+            expect(stringifiedScriptTag)
+                .to.be.a("string")
+                .that.equals(`<script ${HELMET_ATTRIBUTE}="true" src="foo.js" async></script>`);
+        });
+        after(() => {
+            Helmet.canUseDOM = true;
+        });
+    });
+
+    describe("misc", () => {
+        it("throws in rewind() when a DOM is present", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Fancy title"}
+                />,
+                container
+            );
+
+            expect(Helmet.rewind).to.throw(
+                "You may only call rewind() on the server. Call peek() to read the current state."
+            );
+        });
+
+        it("lets you read current state in peek() whether or not a DOM is present", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Fancy title"}
+                />,
+                container
+            );
+
+            expect(Helmet.peek().title).to.be.equal("Fancy title");
+            Helmet.canUseDOM = false;
+            expect(Helmet.peek().title).to.be.equal("Fancy title");
+            Helmet.canUseDOM = true;
+        });
+
+        it("will html encode string", () => {
+            ReactDOM.render(
+                <Helmet
+                    meta={[
+                        {"name": "description", "content": "This is \"quoted\" text and & and '."}
+                    ]}
+                />,
+                container
+            );
+
+            const existingTags = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+            const existingTag = existingTags[0];
+
+            expect(existingTags).to.not.equal(undefined);
+
+            expect(existingTags.length).to.be.equal(1);
+
+            expect(existingTags)
+                .to.have.deep.property("[0]")
+                .that.is.an.instanceof(Element);
+            expect(existingTag).to.have.property("getAttribute");
+            expect(existingTag.getAttribute("name")).to.equal("description");
+            expect(existingTag.getAttribute("content")).to.equal("This is \"quoted\" text and & and '.");
+            expect(existingTag.outerHTML).to.equal(`<meta name="description" content="This is &quot;quoted&quot; text and &amp; and '." ${HELMET_ATTRIBUTE}="true">`);
+        });
+
+        it("will not change the DOM if it is recevies identical props", () => {
+            const spy = sinon.spy();
+            ReactDOM.render(
+                <Helmet
+                    meta={[{"name": "description", "content": "Test description"}]}
+                    title={"Test Title"}
+                    onChangeClientState={spy}
+                />,
+                container
+            );
+
+            // Re-rendering will pass new props to an already mounted Helmet
+            ReactDOM.render(
+                <Helmet
+                    meta={[{"name": "description", "content": "Test description"}]}
+                    title={"Test Title"}
+                    onChangeClientState={spy}
+                />,
+                container
+            );
+
+            expect(spy.callCount).to.equal(1);
+        });
+
+        it("will only add new tags and will perserve tags when rendering additional Helmet instances", () => {
+            const spy = sinon.spy();
+            let addedTags;
+            let removedTags;
+            ReactDOM.render(
+                <Helmet
+                    link={[{"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"}]}
+                    meta={[{"name": "description", "content": "Test description"}]}
+                    onChangeClientState={spy}
+                />,
+                container
+            );
+
+            expect(spy.called).to.equal(true);
+            addedTags = spy.getCall(0).args[1];
+            removedTags = spy.getCall(0).args[2];
+
+            expect(addedTags).to.have.property("metaTags");
+            expect(addedTags.metaTags).to.have.deep.property("[0]");
+            expect(addedTags.metaTags[0].outerHTML).to.equal(`<meta name="description" content="Test description" data-react-helmet="true">`);
+            expect(addedTags).to.have.property("linkTags");
+            expect(addedTags.linkTags).to.have.deep.property("[0]");
+            expect(addedTags.linkTags[0].outerHTML).to.equal(`<link href="http://localhost/style.css" rel="stylesheet" type="text/css" data-react-helmet="true">`);
+            expect(removedTags).to.be.empty;
+
+            // Re-rendering will pass new props to an already mounted Helmet
+            ReactDOM.render(
+                <Helmet
+                    link={[
+                        {"href": "http://localhost/style.css", "rel": "stylesheet", "type": "text/css"},
+                        {"href": "http://localhost/style2.css", "rel": "stylesheet", "type": "text/css"}
+                    ]}
+                    meta={[{"name": "description", "content": "New description"}]}
+                    onChangeClientState={spy}
+                />,
+                container
+            );
+
+            expect(spy.callCount).to.equal(2);
+            addedTags = spy.getCall(1).args[1];
+            removedTags = spy.getCall(1).args[2];
+
+            expect(addedTags).to.have.property("metaTags");
+            expect(addedTags.metaTags).to.have.deep.property("[0]");
+            expect(addedTags.metaTags[0].outerHTML).to.equal(`<meta name="description" content="New description" data-react-helmet="true">`);
+            expect(addedTags).to.have.property("linkTags");
+            expect(addedTags.linkTags).to.have.deep.property("[0]");
+            expect(addedTags.linkTags[0].outerHTML).to.equal(`<link href="http://localhost/style2.css" rel="stylesheet" type="text/css" data-react-helmet="true">`);
+            expect(removedTags).to.have.property("metaTags");
+            expect(removedTags.metaTags).to.have.deep.property("[0]");
+            expect(removedTags.metaTags[0].outerHTML).to.equal(`<meta name="description" content="Test description" data-react-helmet="true">`);
+            expect(removedTags).to.not.have.property("linkTags");
+        });
+
+        it("can not nest Helmets", () => {
+            ReactDOM.render(
+                <Helmet
+                    title={"Test Title"}
+                >
+                    <Helmet
+                        title={"Title you'll never see"}
+                    />
+                </Helmet>,
+                container
+            );
+
+            expect(document.title).to.equal("Test Title");
+        });
+
+        it("will recognize valid tags regardless of attribute ordering", () => {
+            ReactDOM.render(
+                <Helmet
+                    meta={[{"content": "Test Description", "name": "description"}]}
+                />,
+                container
+            );
+
+            const existingTags = headElement.querySelectorAll(`meta[${HELMET_ATTRIBUTE}]`);
+            const existingTag = existingTags[0];
+
+            expect(existingTags).to.not.equal(undefined);
+
+            expect(existingTags.length).to.be.equal(1);
+
+            expect(existingTags)
+                .to.have.deep.property("[0]")
+                .that.is.an.instanceof(Element);
+            expect(existingTag).to.have.property("getAttribute");
+            expect(existingTag.getAttribute("name")).to.equal("description");
+            expect(existingTag.getAttribute("content")).to.equal("Test Description");
+            expect(existingTag.outerHTML).to.equal(`<meta content="Test Description" name="description" ${HELMET_ATTRIBUTE}="true">`);
+        });
+    });
+});

--- a/src/test/HelmetDeclarativeTest.js
+++ b/src/test/HelmetDeclarativeTest.js
@@ -1202,17 +1202,13 @@ describe("Helmet", () => {
             it("will override single link tag with duplicate link tags in a nested component", () => {
                 ReactDOM.render(
                     <div>
-                        <Helmet
-                            link={[
-                                {"rel": "canonical", "href": "http://localhost/helmet"}
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {"rel": "canonical", "href": "http://localhost/helmet/component"},
-                                {"rel": "canonical", "href": "http://localhost/helmet/innercomponent"}
-                            ]}
-                        />
+                        <Helmet>
+                            <link rel="canonical" href="http://localhost/helmet" />
+                        </Helmet>
+                        <Helmet>
+                            <link rel="canonical" href="http://localhost/helmet/component" />
+                            <link rel="canonical" href="http://localhost/helmet/innercomponent" />
+                        </Helmet>
                     </div>,
                     container
                 );
@@ -1245,12 +1241,10 @@ describe("Helmet", () => {
 
             it("won't render tag when primary attribute is null", () => {
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {"rel": "icon", "sizes": "192x192", "href": null},
-                            {"rel": "canonical", "href": "http://localhost/helmet/component"}
-                        ]}
-                    />,
+                    <Helmet>
+                        <link rel="icon" sizes="192x192" href={null} />
+                        <link rel="canonical" href="http://localhost/helmet/component" />
+                    </Helmet>,
                     container
                 );
 

--- a/src/test/HelmetTest.js
+++ b/src/test/HelmetTest.js
@@ -1,4 +1,5 @@
 /* eslint max-nested-callbacks: [1, 5] */
+/* eslint-disable import/no-named-as-default */
 
 import React from "react";
 import ReactDOM from "react-dom";


### PR DESCRIPTION
# Helmet 5

@cwelch5 and I got inspired during React Conf 2017 and worked together to overhaul the Helmet API. This release will replace the current API with, well, _no_ API (...sort of).

Helmet 5 will allow you to rewrite this:

```js
<Helmet
    title="My Title"
    meta={[
        {name: "description", content: "Helmet application"}
    ]}
/>
```

to this:

```js
<Helmet>
    <title>My Title</title>
    <meta name="description" content="Helmet application" />
</Helmet>
```

That's it. There's no need to pass in props or large objects / arrays. Helmet now takes plain HTML tags and outputs plain HTML tags. It's dead simple, and React beginner friendly.

## Minimal API

The Helmet API has been reduced to just two optional convenience props and an optional callback:

```js
<Helmet
    defaultTitle="My Default Title"
    titleTemplate="MySite.com - %s"
    onChangeClientState={(newState) => console.log(newState)}
/>
```

## Reference Example

For a more concrete example, here is the current README example converted to Helmet 5:

```js
<Helmet
    titleTemplate="MySite.com - %s"
    defaultTitle="My Default Title"
    onChangeClientState={(newState) => console.log(newState)}
>
    <html lang="en" amp />

    <title itemProp="name" lang="en">My Title</title>

    <base target="_blank" href="http://mysite.com/" />

    <meta name="description" content="Helmet application" />
    <meta property="og:type" content="article" />

    <link rel="canonical" href="http://mysite.com/example" />
    <link rel="apple-touch-icon" href="http://mysite.com/img/apple-touch-icon-57x57.png" />
    <link rel="apple-touch-icon" sizes-"72x72" href="http://mysite.com/img/apple-touch-icon-72x72.png" />

    <script src="http://include.com/pathtojs.js" type="text/javascript" />
    <script type="application/ld+json">{`
        { "@context": "http://schema.org" }
    `}</script>

    <noscript>{`
        <link rel="stylesheet" type="text/css" href="foo.css" />
    `}</noscript>

    <style type="text/css">{`
        "body {background-color: blue;} p {font-size: 12px;}"
    `}</style>
</Helmet>
```

## Todo

We have a few more items to check off, but we are excited for this release!

- [x] Rewrite Helmet API
    - [x] Maintain backward compatibility with Helmet 4
    - [x] Ensure unit tests pass using either API
    - [x] Document the new API
- [x] Add `Helmet.renderStatic()` alias to `Helmet.rewind()` to reduce confusion on what it does
- [x] Add a `{Helmet}` export for full ES Module compatibility
- [x] Add support for `<body>` attributes
- [x] Use `requestIdleCallback` for DOM writes

## Preview

Please feel free to help us out by installing and test-driving our preview release. Feedback is much appreciated!

```
yarn add react-helmet@next
```

or:

```
npm install react-helmet@next
```
