### PR TITLE
Fix title in React component example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ function HTML () {
     return (
         <html {...htmlAttrs}>
             <head>
-                <title>{helmet.title.toComponent()}</title>
+                {helmet.title.toComponent()}
                 {helmet.meta.toComponent()}
                 {helmet.link.toComponent()}
             </head>


### PR DESCRIPTION
The `<title>` tag is generated by react-helmet. The example would generate a title tag within a title tag.