### PR TITLE
Add support for anything renderable as children rather than just strings.

### DIFF
--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -46,6 +46,23 @@ describe("Helmet - Declarative API", () => {
                 });
             });
 
+            it("updates page title and allows children containing expressions", (done) => {
+                const someValue = "Some Great Title";
+
+                ReactDOM.render(
+                    <Helmet>
+                        <title>Title: {someValue}</title>
+                    </Helmet>,
+                    container
+                );
+
+                requestIdleCallback(() => {
+                    expect(document.title).to.equal("Title: Some Great Title");
+
+                    done();
+                });
+            });
+
             it("updates page title with multiple children", (done) => {
                 ReactDOM.render(
                     <div>


### PR DESCRIPTION
Hi all,

We recently upgraded to v5.0.3 and ran across the following error:
![image](https://cloud.githubusercontent.com/assets/1574487/25458716/4d50c5c8-2a98-11e7-8956-fe8462cb4be8.png)

The error is due to only children of type `string` being supported rather than anything renderable. This PR contains a failing test with a example of using JS expressions within children.

From React docs https://facebook.github.io/react/docs/jsx-in-depth.html#children-in-jsx

> In JSX expressions that contain both an opening tag and a closing tag, the content between those tags is passed as a special prop: props.children. There are several different ways to pass children [...]

Where children can typically be anything that can be rendered: numbers, strings, elements or an array (or fragment) containing these types (from [PropTypes.children](https://facebook.github.io/react/docs/typechecking-with-proptypes.html#proptypes))

With the current API, I would expect `children` of these various types to be supported. However for example, `<title>` requires the `children` to be `string`s.

To summarize by examples:

```js
const title = 'The Title';

// Works
<Helmet>
  <title>Title: The Title</title>
</Helmet>

// Works
<Helmet>
  <title>{'Title: The Title'}</title>
</Helmet>

// Works
<Helmet>
  <title>{'Title: ' + title}</title>
</Helmet>

// Doesn't Work
<Helmet>
  <title>Title: {title}</title>
</Helmet>
```