### PR TITLE
Use prop "helmetKey" if it's present as primary attribute.

### DIFF
--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -28,6 +28,7 @@ export const TAG_PROPERTIES = {
     HTTPEQUIV: "http-equiv",
     INNER_HTML: "innerHTML",
     ITEM_PROP: "itemprop",
+    KEY: "helmetKey",
     NAME: "name",
     PROPERTY: "property",
     REL: "rel",

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -126,6 +126,12 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                     ) {
                         primaryAttributeKey = attributeKey;
                     }
+
+                    // Special rule for 'key' prop, which takes over the normal priority mechanism
+                    if(attributeKey === TAG_PROPERTIES.KEY) {
+                      primaryAttributeKey = attributeKey;
+                      break;
+                    }
                 }
 
                 if (!primaryAttributeKey || !tag[primaryAttributeKey]) {


### PR DESCRIPTION
This allows more fine-grained control over which tags are duplicated vs
overwritten.

* Tags of the same type with the same value in "helmetKey" will be overwritten, even if the would normally be duplicated.
* Tags of the same type with different values in "helmetKey" will be duplicated, even if they would normally be overwritten.