### PR TITLE
Adds support for synchronously updated tags (Closes #291)

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -17,6 +17,7 @@ const Helmet = Component =>
      * @param {Object} base: {"target": "_blank", "href": "http://mysite.com/"}
      * @param {Object} bodyAttributes: {"className": "root"}
      * @param {String} defaultTitle: "Default Title"
+     * @param {Boolean} defer: true
      * @param {Boolean} encodeSpecialCharacters: true
      * @param {Object} htmlAttributes: {"lang": "en", "amp": undefined}
      * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example"}]
@@ -37,6 +38,7 @@ const Helmet = Component =>
                 PropTypes.node
             ]),
             defaultTitle: PropTypes.string,
+            defer: PropTypes.bool,
             encodeSpecialCharacters: PropTypes.bool,
             htmlAttributes: PropTypes.object,
             link: PropTypes.arrayOf(PropTypes.object),
@@ -51,6 +53,7 @@ const Helmet = Component =>
         };
 
         static defaultProps = {
+            defer: true,
             encodeSpecialCharacters: true
         };
 

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -47,6 +47,7 @@ export const REACT_TAG_MAP = {
 
 export const HELMET_PROPS = {
     DEFAULT_TITLE: "defaultTitle",
+    DEFER: "defer",
     ENCODE_SPECIAL_CHARACTERS: "encodeSpecialCharacters",
     ON_CHANGE_CLIENT_STATE: "onChangeClientState",
     TITLE_TEMPLATE: "titleTemplate"

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -2501,6 +2501,42 @@ describe("Helmet - Declarative API", () => {
         });
     });
 
+    describe("deferred tags", () => {
+        beforeEach(() => {
+            window.__spy__ = sinon.spy();
+        });
+
+        afterEach(() => {
+            delete window.__spy__;
+        });
+
+        it("executes synchronously when defer={true} and async otherwise", done => {
+            ReactDOM.render(
+                <div>
+                    <Helmet defer={false}>
+                        <script>
+                            window.__spy__(1)
+                        </script>
+                    </Helmet>
+                    <Helmet>
+                        <script>
+                            window.__spy__(2)
+                        </script>
+                    </Helmet>
+                </div>,
+                container
+            );
+
+            expect(window.__spy__.callCount).to.equal(1);
+
+            requestIdleCallback(() => {
+                expect(window.__spy__.callCount).to.equal(2);
+                expect(window.__spy__.args).to.deep.equal([[1], [2]]);
+                done();
+            });
+        });
+    });
+
     describe("server", () => {
         const stringifiedHtmlAttributes = `lang="ga" class="myClassName"`;
         const stringifiedBodyAttributes = `lang="ga" class="myClassName"`;

--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -2271,6 +2271,47 @@ describe("Helmet", () => {
         });
     });
 
+    describe("deferred tags", () => {
+        beforeEach(() => {
+            window.__spy__ = sinon.spy();
+        });
+
+        afterEach(() => {
+            delete window.__spy__;
+        });
+
+        it("executes synchronously when defer={true} and async otherwise", done => {
+            ReactDOM.render(
+                <div>
+                    <Helmet
+                        defer={false}
+                        script={[
+                            {
+                                innerHTML: `window.__spy__(1)`
+                            }
+                        ]}
+                    />
+                    <Helmet
+                        script={[
+                            {
+                                innerHTML: `window.__spy__(2)`
+                            }
+                        ]}
+                    />
+                </div>,
+                container
+            );
+
+            expect(window.__spy__.callCount).to.equal(1);
+
+            requestIdleCallback(() => {
+                expect(window.__spy__.callCount).to.equal(2);
+                expect(window.__spy__.args).to.deep.equal([[1], [2]]);
+                done();
+            });
+        });
+    });
+
     describe("server", () => {
         const stringifiedHtmlAttributes = `lang="ga" class="myClassName"`;
         const stringifiedTitle = `<title ${HELMET_ATTRIBUTE}="true">Dangerous &lt;script&gt; include</title>`;


### PR DESCRIPTION
This PR is to address the issue with FOUC as outlined in #291.

The code changes involve splitting the updates into two groups: deferred (default), and sync. The sync behaviour is opt-in using the new `defer={false}` prop on `Helmet`.

```js
<div>
  <Helmet defer={false}>
    {/* These updates will be sync during the render cycle.
      * By including <style> tags here, you can avoid FOUC
      * of the rendering element as outlined in #291. 
      */}
  </Helmet>
  <Helmet>
    {/* These updates will be async during the render cycle. */}
  </Helmet>
</div>
```

Two new **tests** have been added to both declarative and original API. They both test that updates can happen before `requestIdleCallback` and during.
