### PR TITLE
Add onLoad attribute to `<link>` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ function HTML () {
         }
     `}</script>
 
+    {/* link elements */}
+    <link onLoad="doSomethingInteresting()" rel="stylesheet" media="all" type="text/css" href="critical-style.css" />
+    <link onLoad="if(media!='all')media='all'" rel="stylesheet" media="none" type="text/css" href="non-critical-style.css" />
+
     {/* noscript elements */}
     <noscript>{`
         <link rel="stylesheet" type="text/css" href="foo.css" />

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -20,7 +20,7 @@ const Helmet = Component =>
      * @param {Boolean} defer: true
      * @param {Boolean} encodeSpecialCharacters: true
      * @param {Object} htmlAttributes: {"lang": "en", "amp": undefined}
-     * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example"}]
+     * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example", "onLoad": "functionCall()"}]
      * @param {Array} meta: [{"name": "description", "content": "Test description"}]
      * @param {Array} noscript: [{"innerHTML": "<img src='http://mysite.com/js/test.js'"}]
      * @param {Function} onChangeClientState: "(newState) => console.log(newState)"

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -20,7 +20,7 @@ const Helmet = Component =>
      * @param {Boolean} defer: true
      * @param {Boolean} encodeSpecialCharacters: true
      * @param {Object} htmlAttributes: {"lang": "en", "amp": undefined}
-     * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example", "onLoad": "functionCall()"}]
+     * @param {Array} link: [{"rel": "canonical", "href": "http://mysite.com/example", "onLoad": "functionCall()", "onError": "functionCall()"}]
      * @param {Array} meta: [{"name": "description", "content": "Test description"}]
      * @param {Array} noscript: [{"innerHTML": "<img src='http://mysite.com/js/test.js'"}]
      * @param {Function} onChangeClientState: "(newState) => console.log(newState)"

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -32,7 +32,8 @@ export const TAG_PROPERTIES = {
     PROPERTY: "property",
     REL: "rel",
     SRC: "src",
-    ONLOAD: "onload"
+    ONLOAD: "onload",
+    ONERROR: "onerror"
 };
 
 export const REACT_TAG_MAP = {

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -31,7 +31,8 @@ export const TAG_PROPERTIES = {
     NAME: "name",
     PROPERTY: "property",
     REL: "rel",
-    SRC: "src"
+    SRC: "src",
+    ONLOAD: "onload"
 };
 
 export const REACT_TAG_MAP = {

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -217,7 +217,12 @@ const reducePropsToState = propsList => ({
     htmlAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.HTML, propsList),
     linkTags: getTagsFromPropsList(
         TAG_NAMES.LINK,
-        [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF, TAG_PROPERTIES.ONLOAD],
+        [
+            TAG_PROPERTIES.REL,
+            TAG_PROPERTIES.HREF,
+            TAG_PROPERTIES.ONLOAD,
+            TAG_PROPERTIES.ONERROR
+        ],
         propsList
     ),
     metaTags: getTagsFromPropsList(
@@ -273,19 +278,21 @@ const rafPolyfill = (() => {
 
 const cafPolyfill = (id: string | number) => clearTimeout(id);
 
-const requestAnimationFrame = typeof window !== "undefined"
-    ? window.requestAnimationFrame ||
+const requestAnimationFrame =
+    typeof window !== "undefined"
+        ? window.requestAnimationFrame ||
           window.webkitRequestAnimationFrame ||
           window.mozRequestAnimationFrame ||
           rafPolyfill
-    : global.requestAnimationFrame || rafPolyfill;
+        : global.requestAnimationFrame || rafPolyfill;
 
-const cancelAnimationFrame = typeof window !== "undefined"
-    ? window.cancelAnimationFrame ||
+const cancelAnimationFrame =
+    typeof window !== "undefined"
+        ? window.cancelAnimationFrame ||
           window.webkitCancelAnimationFrame ||
           window.mozCancelAnimationFrame ||
           cafPolyfill
-    : global.cancelAnimationFrame || cafPolyfill;
+        : global.cancelAnimationFrame || cafPolyfill;
 
 const warn = msg => {
     return console && typeof console.warn === "function" && console.warn(msg);
@@ -442,9 +449,10 @@ const updateTags = (type, tags) => {
                             );
                         }
                     } else {
-                        const value = typeof tag[attribute] === "undefined"
-                            ? ""
-                            : tag[attribute];
+                        const value =
+                            typeof tag[attribute] === "undefined"
+                                ? ""
+                                : tag[attribute];
                         newElement.setAttribute(attribute, value);
                     }
                 }
@@ -477,9 +485,10 @@ const updateTags = (type, tags) => {
 
 const generateElementAttributesAsString = attributes =>
     Object.keys(attributes).reduce((str, key) => {
-        const attr = typeof attributes[key] !== "undefined"
-            ? `${key}="${attributes[key]}"`
-            : `${key}`;
+        const attr =
+            typeof attributes[key] !== "undefined"
+                ? `${key}="${attributes[key]}"`
+                : `${key}`;
         return str ? `${str} ${attr}` : attr;
     }, "");
 
@@ -508,12 +517,13 @@ const generateTagsAsString = (type, tags, encode) =>
                     )
             )
             .reduce((string, attribute) => {
-                const attr = typeof tag[attribute] === "undefined"
-                    ? attribute
-                    : `${attribute}="${encodeSpecialCharacters(
-                          tag[attribute],
-                          encode
-                      )}"`;
+                const attr =
+                    typeof tag[attribute] === "undefined"
+                        ? attribute
+                        : `${attribute}="${encodeSpecialCharacters(
+                              tag[attribute],
+                              encode
+                          )}"`;
                 return string ? `${string} ${attr}` : attr;
             }, "");
 

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -217,7 +217,7 @@ const reducePropsToState = propsList => ({
     htmlAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.HTML, propsList),
     linkTags: getTagsFromPropsList(
         TAG_NAMES.LINK,
-        [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF],
+        [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF, TAG_PROPERTIES.ONLOAD],
         propsList
     ),
     metaTags: getTagsFromPropsList(

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -268,7 +268,9 @@ describe("Helmet - Declarative API", () => {
             it("properly handles title with children and titleTemplate", done => {
                 ReactDOM.render(
                     <Helmet titleTemplate={"This is an %s"}>
-                        <title>{"extra"} + {"test"}</title>
+                        <title>
+                            {"extra"} + {"test"}
+                        </title>
                     </Helmet>,
                     container
                 );
@@ -2102,7 +2104,7 @@ describe("Helmet - Declarative API", () => {
                     container
                 );
 
-                requestIdleCallback(() => {
+                requestAnimationFrame(() => {
                     const tagNodes = headElement.querySelectorAll(
                         `link[${HELMET_ATTRIBUTE}]`
                     );

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -2087,7 +2087,7 @@ describe("Helmet - Declarative API", () => {
                     <Helmet>
                         <link
                             onLoad="functionCall()"
-                            onError="handleErrorFunc()"
+                            onError="errorFunctionCall()"
                             rel="stylesheet"
                             media="all"
                             type="text/css"
@@ -2125,13 +2125,13 @@ describe("Helmet - Declarative API", () => {
                         "functionCall()"
                     );
                     expect(firstTag.getAttribute("onerror")).to.equal(
-                        "handleErrorFunc()"
+                        "errorFunctionCall()"
                     );
                     expect(firstTag.getAttribute("href")).to.equal(
                         "http://localhost/critical-style.css"
                     );
                     expect(firstTag.outerHTML).to.equal(
-                        `<link onload="functionCall()" onerror="handleErrorFunc()" rel="stylesheet" media="all" type="text/css" href="http://localhost/critical-style.css" ${HELMET_ATTRIBUTE}="true">`
+                        `<link onload="functionCall()" onerror="errorFunctionCall()" rel="stylesheet" media="all" type="text/css" href="http://localhost/critical-style.css" ${HELMET_ATTRIBUTE}="true">`
                     );
 
                     const secondTag = existingTags[1];

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -2073,6 +2073,51 @@ describe("Helmet - Declarative API", () => {
                     done();
                 });
             });
+
+            it("renders tag when onload attribute is present", (done) => {
+                ReactDOM.render(
+                    <Helmet>
+                        <link onLoad="functionCall()" rel="stylesheet" media="all" type="text/css" href="http://localhost/critical-style.css" />
+                        <link onLoad="if(media!='all')media='all'" rel="stylesheet" media="none" type="text/css" href="http://localhost/non-critical-style.css" />
+                    </Helmet>,
+                    container
+                );
+
+                requestIdleCallback(() => {
+                    const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                    const existingTags = Array.prototype.slice.call(tagNodes);
+                    const firstTag = existingTags[0];
+
+                    expect(existingTags).to.not.equal(undefined);
+                    expect(existingTags.length).to.be.equal(2);
+
+                    expect(existingTags)
+                        .to.have.deep.property("[0]")
+                        .that.is.an.instanceof(Element);
+                    expect(firstTag).to.have.property("getAttribute");
+                    expect(firstTag.getAttribute("rel")).to.equal("stylesheet");
+                    expect(firstTag.getAttribute("media")).to.equal("all");
+                    expect(firstTag.getAttribute("type")).to.equal("text/css");
+                    expect(firstTag.getAttribute("onload")).to.equal("functionCall()");
+                    expect(firstTag.getAttribute("href")).to.equal("http://localhost/critical-style.css");
+                    expect(firstTag.outerHTML).to.equal(`<link onload="functionCall()" rel="stylesheet" media="all" type="text/css" href="http://localhost/critical-style.css" ${HELMET_ATTRIBUTE}="true">`);
+
+                    const secondTag = existingTags[1];
+
+                    expect(existingTags)
+                        .to.have.deep.property("[1]")
+                        .that.is.an.instanceof(Element);
+                    expect(secondTag).to.have.property("getAttribute");
+                    expect(secondTag.getAttribute("rel")).to.equal("stylesheet");
+                    expect(secondTag.getAttribute("media")).to.equal("none");
+                    expect(secondTag.getAttribute("type")).to.equal("text/css");
+                    expect(secondTag.getAttribute("onload")).to.equal("if(media!='all')media='all'");
+                    expect(secondTag.getAttribute("href")).to.equal("http://localhost/non-critical-style.css");
+                    expect(secondTag.outerHTML).to.equal(`<link onload="if(media!='all')media='all'" rel="stylesheet" media="none" type="text/css" href="http://localhost/non-critical-style.css" ${HELMET_ATTRIBUTE}="true">`);
+
+                    done();
+                });
+            });
         });
 
         describe("script tags", () => {

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -50,7 +50,9 @@ describe("Helmet - Declarative API", () => {
 
                 ReactDOM.render(
                     <Helmet>
-                        <title>Title: {someValue}</title>
+                        <title>
+                            Title: {someValue}
+                        </title>
                     </Helmet>,
                     container
                 );
@@ -247,7 +249,9 @@ describe("Helmet - Declarative API", () => {
 
                 ReactDOM.render(
                     <Helmet titleTemplate={"This is a %s"}>
-                        <title>{dollarTitle}</title>
+                        <title>
+                            {dollarTitle}
+                        </title>
                     </Helmet>,
                     container
                 );
@@ -281,7 +285,9 @@ describe("Helmet - Declarative API", () => {
 
                 ReactDOM.render(
                     <Helmet>
-                        <title>{chineseTitle}</title>
+                        <title>
+                            {chineseTitle}
+                        </title>
                     </Helmet>,
                     container
                 );
@@ -341,7 +347,7 @@ describe("Helmet - Declarative API", () => {
 
                     ReactDOM.render(
                         <Helmet>
-                            <title>{" "}</title>
+                            <title />
                             <meta name="keywords" content="stuff" />
                         </Helmet>,
                         container
@@ -2074,46 +2080,78 @@ describe("Helmet - Declarative API", () => {
                 });
             });
 
-            it("renders tag when onload attribute is present", (done) => {
+            it("renders tag when onload attribute is present", done => {
                 ReactDOM.render(
                     <Helmet>
-                        <link onLoad="functionCall()" rel="stylesheet" media="all" type="text/css" href="http://localhost/critical-style.css" />
-                        <link onLoad="if(media!='all')media='all'" rel="stylesheet" media="none" type="text/css" href="http://localhost/non-critical-style.css" />
+                        <link
+                            onLoad="functionCall()"
+                            onError="handleErrorFunc()"
+                            rel="stylesheet"
+                            media="all"
+                            type="text/css"
+                            href="http://localhost/critical-style.css"
+                        />
+                        <link
+                            onLoad="if(media!='all')media='all'"
+                            rel="stylesheet"
+                            media="none"
+                            type="text/css"
+                            href="http://localhost/non-critical-style.css"
+                        />
                     </Helmet>,
                     container
                 );
 
                 requestIdleCallback(() => {
-                    const tagNodes = headElement.querySelectorAll(`link[${HELMET_ATTRIBUTE}]`);
+                    const tagNodes = headElement.querySelectorAll(
+                        `link[${HELMET_ATTRIBUTE}]`
+                    );
                     const existingTags = Array.prototype.slice.call(tagNodes);
                     const firstTag = existingTags[0];
 
                     expect(existingTags).to.not.equal(undefined);
                     expect(existingTags.length).to.be.equal(2);
 
-                    expect(existingTags)
-                        .to.have.deep.property("[0]")
+                    expect(existingTags).to.have.deep
+                        .property("[0]")
                         .that.is.an.instanceof(Element);
                     expect(firstTag).to.have.property("getAttribute");
                     expect(firstTag.getAttribute("rel")).to.equal("stylesheet");
                     expect(firstTag.getAttribute("media")).to.equal("all");
                     expect(firstTag.getAttribute("type")).to.equal("text/css");
-                    expect(firstTag.getAttribute("onload")).to.equal("functionCall()");
-                    expect(firstTag.getAttribute("href")).to.equal("http://localhost/critical-style.css");
-                    expect(firstTag.outerHTML).to.equal(`<link onload="functionCall()" rel="stylesheet" media="all" type="text/css" href="http://localhost/critical-style.css" ${HELMET_ATTRIBUTE}="true">`);
+                    expect(firstTag.getAttribute("onload")).to.equal(
+                        "functionCall()"
+                    );
+                    expect(firstTag.getAttribute("onerror")).to.equal(
+                        "handleErrorFunc()"
+                    );
+                    expect(firstTag.getAttribute("href")).to.equal(
+                        "http://localhost/critical-style.css"
+                    );
+                    expect(firstTag.outerHTML).to.equal(
+                        `<link onload="functionCall()" onerror="handleErrorFunc()" rel="stylesheet" media="all" type="text/css" href="http://localhost/critical-style.css" ${HELMET_ATTRIBUTE}="true">`
+                    );
 
                     const secondTag = existingTags[1];
 
-                    expect(existingTags)
-                        .to.have.deep.property("[1]")
+                    expect(existingTags).to.have.deep
+                        .property("[1]")
                         .that.is.an.instanceof(Element);
                     expect(secondTag).to.have.property("getAttribute");
-                    expect(secondTag.getAttribute("rel")).to.equal("stylesheet");
+                    expect(secondTag.getAttribute("rel")).to.equal(
+                        "stylesheet"
+                    );
                     expect(secondTag.getAttribute("media")).to.equal("none");
                     expect(secondTag.getAttribute("type")).to.equal("text/css");
-                    expect(secondTag.getAttribute("onload")).to.equal("if(media!='all')media='all'");
-                    expect(secondTag.getAttribute("href")).to.equal("http://localhost/non-critical-style.css");
-                    expect(secondTag.outerHTML).to.equal(`<link onload="if(media!='all')media='all'" rel="stylesheet" media="none" type="text/css" href="http://localhost/non-critical-style.css" ${HELMET_ATTRIBUTE}="true">`);
+                    expect(secondTag.getAttribute("onload")).to.equal(
+                        "if(media!='all')media='all'"
+                    );
+                    expect(secondTag.getAttribute("href")).to.equal(
+                        "http://localhost/non-critical-style.css"
+                    );
+                    expect(secondTag.outerHTML).to.equal(
+                        `<link onload="if(media!='all')media='all'" rel="stylesheet" media="none" type="text/css" href="http://localhost/non-critical-style.css" ${HELMET_ATTRIBUTE}="true">`
+                    );
 
                     done();
                 });
@@ -2353,7 +2391,9 @@ describe("Helmet - Declarative API", () => {
                 const noscriptInnerHTML = `<link rel="stylesheet" type="text/css" href="foo.css" />`;
                 ReactDOM.render(
                     <Helmet>
-                        <noscript id="bar">{noscriptInnerHTML}</noscript>
+                        <noscript id="bar">
+                            {noscriptInnerHTML}
+                        </noscript>
                     </Helmet>,
                     container
                 );
@@ -2421,7 +2461,9 @@ describe("Helmet - Declarative API", () => {
             it("does not render tag when primary attribute is null", done => {
                 ReactDOM.render(
                     <Helmet>
-                        <noscript>{undefined}</noscript>
+                        <noscript>
+                            {undefined}
+                        </noscript>
                     </Helmet>,
                     container
                 );
@@ -2453,8 +2495,12 @@ describe("Helmet - Declarative API", () => {
 
                 ReactDOM.render(
                     <Helmet>
-                        <style type="text/css">{cssText1}</style>
-                        <style>{cssText2}</style>
+                        <style type="text/css">
+                            {cssText1}
+                        </style>
+                        <style>
+                            {cssText2}
+                        </style>
                     </Helmet>,
                     container
                 );
@@ -2499,7 +2545,9 @@ describe("Helmet - Declarative API", () => {
                 `;
                 ReactDOM.render(
                     <Helmet>
-                        <style type="text/css">{cssText}</style>
+                        <style type="text/css">
+                            {cssText}
+                        </style>
                     </Helmet>,
                     container
                 );
@@ -2543,7 +2591,9 @@ describe("Helmet - Declarative API", () => {
             it("does not render tag when primary attribute is null", done => {
                 ReactDOM.render(
                     <Helmet>
-                        <style>{undefined}</style>
+                        <style>
+                            {undefined}
+                        </style>
                     </Helmet>,
                     container
                 );
@@ -2574,14 +2624,10 @@ describe("Helmet - Declarative API", () => {
             ReactDOM.render(
                 <div>
                     <Helmet defer={false}>
-                        <script>
-                            window.__spy__(1)
-                        </script>
+                        <script>window.__spy__(1)</script>
                     </Helmet>
                     <Helmet>
-                        <script>
-                            window.__spy__(2)
-                        </script>
+                        <script>window.__spy__(2)</script>
                     </Helmet>
                 </div>,
                 container
@@ -2667,7 +2713,9 @@ describe("Helmet - Declarative API", () => {
         it("opts out of string encoding", () => {
             ReactDOM.render(
                 <Helmet encodeSpecialCharacters={false}>
-                    <title>{"This is text and & and '."}</title>
+                    <title>
+                        {"This is text and & and '."}
+                    </title>
                 </Helmet>,
                 container
             );
@@ -2971,7 +3019,9 @@ describe("Helmet - Declarative API", () => {
         it("renders title tag as string", () => {
             ReactDOM.render(
                 <Helmet>
-                    <title>{"Dangerous <script> include"}</title>
+                    <title>
+                        {"Dangerous <script> include"}
+                    </title>
                 </Helmet>,
                 container
             );
@@ -2991,7 +3041,9 @@ describe("Helmet - Declarative API", () => {
 
             ReactDOM.render(
                 <Helmet>
-                    <title>Title: {someValue}</title>
+                    <title>
+                        Title: {someValue}
+                    </title>
                 </Helmet>,
                 container
             );
@@ -3226,7 +3278,9 @@ describe("Helmet - Declarative API", () => {
             ReactDOM.render(
                 <div>
                     <Helmet>
-                        <title>{chineseTitle}</title>
+                        <title>
+                            {chineseTitle}
+                        </title>
                     </Helmet>
                 </div>,
                 container


### PR DESCRIPTION
This PR is to address the issue of absence of `onLoad` attribute on `<link>` tags.

The code changes involve adding new tag property, `onload`,  to `HelmetConstants.js`

This allows the ability to add the following variations of `<link>` tags.
```source-js
<div>
  <Helmet>
     {/* link elements */}
      <link onLoad="doSomethingInteresting()" rel="stylesheet" media="all" type="text/css" href="critical-style.css" />
      <link onLoad="if(media!='all')media='all'" rel="stylesheet" media="none" type="text/css" href="non-critical-style.css" />
  </Helmet>
</div>
```

Two new **tests** have also been added to both declarative API. They test the rendered output of the tag elements.