### PR TITLE
Fix titleTemplate bug with multiple title children components

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -33,7 +33,13 @@ const getTitleFromPropsList = propsList => {
 
     if (innermostTemplate && innermostTitle) {
         // use function arg to avoid need to escape $ characters
-        return innermostTemplate.replace(/%s/g, () => innermostTitle);
+        return innermostTemplate.replace(
+            /%s/g,
+            () =>
+                Array.isArray(innermostTitle)
+                    ? innermostTitle.join("")
+                    : innermostTitle
+        );
     }
 
     const innermostDefaultTitle = getInnermostProperty(

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -261,6 +261,21 @@ describe("Helmet - Declarative API", () => {
                 });
             });
 
+            it("properly handles title with children and titleTemplate", done => {
+                ReactDOM.render(
+                    <Helmet titleTemplate={"This is an %s"}>
+                        <title>{"extra"} + {"test"}</title>
+                    </Helmet>,
+                    container
+                );
+
+                requestAnimationFrame(() => {
+                    expect(document.title).to.equal("This is an extra + test");
+
+                    done();
+                });
+            });
+
             it("does not encode all characters with HTML character entity equivalents", done => {
                 const chineseTitle = "膣膗 鍆錌雔";
 


### PR DESCRIPTION
I discovered a bug when using `titleTemplate` with a component that essentially renders a `<title>` with multiple child components (see the test case for an accurate simulation of this use case). This pull request fixes that behavior by calling `innermostTitle.join('')` when doing the template replacement for `innermostTitle`s that are arrays.