### PR TITLE
Make react-helmet thread safe & add support for renderToNodeStream()

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "object-assign": "^4.1.1",
-    "react-side-effect": "^1.1.0",
-    "prop-types": "^15.5.4"
+    "prop-types": "^15.5.4",
+    "react-reffect": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -5,7 +5,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import ReactServer from "react-dom/server";
-import {Helmet} from "../src/Helmet";
+import {Helmet, HelmetProvider, createHelmetStore} from "../src/Helmet";
 import {HTML_TAG_MAP} from "../src/HelmetConstants";
 import {requestAnimationFrame} from "../src/HelmetUtils.js";
 
@@ -31,10 +31,13 @@ describe("Helmet - Declarative API", () => {
     describe("api", () => {
         describe("title", () => {
             it("updates page title", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet defaultTitle={"Fallback"}>
-                        <title>Test Title</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet defaultTitle={"Fallback"}>
+                            <title>Test Title</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -46,12 +49,15 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates page title and allows children containing expressions", done => {
+                const store = createHelmetStore();
                 const someValue = "Some Great Title";
 
                 ReactDOM.render(
-                    <Helmet>
-                        <title>Title: {someValue}</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title>Title: {someValue}</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -63,18 +69,21 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates page title with multiple children", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <title>Test Title</title>
-                        </Helmet>
-                        <Helmet>
-                            <title>Child One Title</title>
-                        </Helmet>
-                        <Helmet>
-                            <title>Child Two Title</title>
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <title>Test Title</title>
+                            </Helmet>
+                            <Helmet>
+                                <title>Child One Title</title>
+                            </Helmet>
+                            <Helmet>
+                                <title>Child Two Title</title>
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -86,15 +95,18 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets title based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <title>Main Title</title>
-                        </Helmet>
-                        <Helmet>
-                            <title>Nested Title</title>
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <title>Main Title</title>
+                            </Helmet>
+                            <Helmet>
+                                <title>Nested Title</title>
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -106,13 +118,16 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets title using deepest nested component with a defined title", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <title>Main Title</title>
-                        </Helmet>
-                        <Helmet />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <title>Main Title</title>
+                            </Helmet>
+                            <Helmet />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -124,15 +139,18 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("uses defaultTitle if no title is defined", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        defaultTitle={"Fallback"}
-                        titleTemplate={
-                            "This is a %s of the titleTemplate feature"
-                        }
-                    >
-                        <title />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            defaultTitle={"Fallback"}
+                            titleTemplate={
+                                "This is a %s of the titleTemplate feature"
+                            }
+                        >
+                            <title />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -144,15 +162,18 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("uses a titleTemplate if defined", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        defaultTitle={"Fallback"}
-                        titleTemplate={
-                            "This is a %s of the titleTemplate feature"
-                        }
-                    >
-                        <title>Test</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            defaultTitle={"Fallback"}
+                            titleTemplate={
+                                "This is a %s of the titleTemplate feature"
+                            }
+                        >
+                            <title>Test</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -166,14 +187,17 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("replaces multiple title strings in titleTemplate", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        titleTemplate={
-                            "This is a %s of the titleTemplate feature. Another %s."
-                        }
-                    >
-                        <title>Test</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            titleTemplate={
+                                "This is a %s of the titleTemplate feature. Another %s."
+                            }
+                        >
+                            <title>Test</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -187,23 +211,26 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("uses a titleTemplate based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            titleTemplate={
-                                "This is a %s of the titleTemplate feature"
-                            }
-                        >
-                            <title>Test</title>
-                        </Helmet>
-                        <Helmet
-                            titleTemplate={
-                                "A %s using nested titleTemplate attributes"
-                            }
-                        >
-                            <title>Second Test</title>
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                titleTemplate={
+                                    "This is a %s of the titleTemplate feature"
+                                }
+                            >
+                                <title>Test</title>
+                            </Helmet>
+                            <Helmet
+                                titleTemplate={
+                                    "A %s using nested titleTemplate attributes"
+                                }
+                            >
+                                <title>Second Test</title>
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -217,19 +244,22 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("merges deepest component title with nearest upstream titleTemplate", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            titleTemplate={
-                                "This is a %s of the titleTemplate feature"
-                            }
-                        >
-                            <title>Test</title>
-                        </Helmet>
-                        <Helmet>
-                            <title>Second Test</title>
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                titleTemplate={
+                                    "This is a %s of the titleTemplate feature"
+                                }
+                            >
+                                <title>Test</title>
+                            </Helmet>
+                            <Helmet>
+                                <title>Second Test</title>
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -243,12 +273,15 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("renders dollar characters in a title correctly when titleTemplate present", done => {
+                const store = createHelmetStore();
                 const dollarTitle = "te$t te$$t te$$$t te$$$$t";
 
                 ReactDOM.render(
-                    <Helmet titleTemplate={"This is a %s"}>
-                        <title>{dollarTitle}</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet titleTemplate={"This is a %s"}>
+                            <title>{dollarTitle}</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -262,10 +295,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("properly handles title with children and titleTemplate", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet titleTemplate={"This is an %s"}>
-                        <title>{"extra"} + {"test"}</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet titleTemplate={"This is an %s"}>
+                            <title>{"extra"} + {"test"}</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -277,12 +313,15 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not encode all characters with HTML character entity equivalents", done => {
+                const store = createHelmetStore();
                 const chineseTitle = "膣膗 鍆錌雔";
 
                 ReactDOM.render(
-                    <Helmet>
-                        <title>{chineseTitle}</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title>{chineseTitle}</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -294,10 +333,15 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("page title with prop itemProp", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet defaultTitle={"Fallback"}>
-                        <title itemProp="name">Test Title with itemProp</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet defaultTitle={"Fallback"}>
+                            <title itemProp="name">
+                                Test Title with itemProp
+                            </title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -311,12 +355,15 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("retains existing title tag when no title tag is defined", done => {
+                const store = createHelmetStore();
                 headElement.innerHTML = `<title>Existing Title</title>`;
 
                 ReactDOM.render(
-                    <Helmet>
-                        <meta name="keywords" content="stuff" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <meta name="keywords" content="stuff" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -328,11 +375,14 @@ describe("Helmet - Declarative API", () => {
             });
 
             it.skip("clears title tag if empty title is defined", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <title>Existing Title</title>
-                        <meta name="keywords" content="stuff" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title>Existing Title</title>
+                            <meta name="keywords" content="stuff" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -340,10 +390,12 @@ describe("Helmet - Declarative API", () => {
                     expect(document.title).to.equal("Existing Title");
 
                     ReactDOM.render(
-                        <Helmet>
-                            <title>{" "}</title>
-                            <meta name="keywords" content="stuff" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <title />
+                                <meta name="keywords" content="stuff" />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
@@ -361,10 +413,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates title attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <title itemProp="name" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title itemProp="name" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -381,15 +436,18 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets attributes based on the deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <title lang="en" hidden />
-                        </Helmet>
-                        <Helmet>
-                            <title lang="ja" />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <title lang="en" hidden />
+                            </Helmet>
+                            <Helmet>
+                                <title lang="ja" />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -407,10 +465,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("handles valueless attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <title hidden />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title hidden />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -427,15 +488,23 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears title attributes that are handled within helmet", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <title lang="en" hidden />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title lang="en" hidden />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const titleTag = document.getElementsByTagName(
@@ -456,10 +525,13 @@ describe("Helmet - Declarative API", () => {
 
         describe("html attributes", () => {
             it("updates html attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <html className="myClassName" lang="en" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <html className="myClassName" lang="en" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -479,15 +551,18 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets attributes based on the deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <html lang="en" />
-                        </Helmet>
-                        <Helmet>
-                            <html lang="ja" />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <html lang="en" />
+                            </Helmet>
+                            <Helmet>
+                                <html lang="ja" />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -504,10 +579,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("handles valueless attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <html amp />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <html amp />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -524,15 +602,23 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears html attributes that are handled within helmet", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <html lang="en" amp />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <html lang="en" amp />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const htmlTag = document.getElementsByTagName(
@@ -551,18 +637,27 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates with multiple additions and removals - overwrite and new", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <html lang="en" amp />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <html lang="en" amp />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
                     ReactDOM.render(
-                        <Helmet>
-                            <html lang="ja" id="html-tag" title="html tag" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <html
+                                    lang="ja"
+                                    id="html-tag"
+                                    title="html tag"
+                                />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
@@ -587,18 +682,23 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates with multiple additions and removals - all new", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <html lang="en" amp />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <html lang="en" amp />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
                     ReactDOM.render(
-                        <Helmet>
-                            <html id="html-tag" title="html tag" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <html id="html-tag" title="html tag" />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
@@ -629,7 +729,13 @@ describe("Helmet - Declarative API", () => {
                 });
 
                 it("are not cleared", done => {
-                    ReactDOM.render(<Helmet />, container);
+                    const store = createHelmetStore();
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const htmlTag = document.getElementsByTagName(
@@ -646,10 +752,13 @@ describe("Helmet - Declarative API", () => {
                 });
 
                 it("overwritten if specified in helmet", done => {
+                    const store = createHelmetStore();
                     ReactDOM.render(
-                        <Helmet>
-                            <html test="helmet-attr" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <html test="helmet-attr" />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
@@ -670,15 +779,23 @@ describe("Helmet - Declarative API", () => {
                 });
 
                 it("cleared once it is managed in helmet", done => {
+                    const store = createHelmetStore();
                     ReactDOM.render(
-                        <Helmet>
-                            <html test="helmet-attr" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <html test="helmet-attr" />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
                     requestAnimationFrame(() => {
-                        ReactDOM.render(<Helmet />, container);
+                        ReactDOM.render(
+                            <HelmetProvider store={store}>
+                                <Helmet />
+                            </HelmetProvider>,
+                            container
+                        );
 
                         requestAnimationFrame(() => {
                             const htmlTag = document.getElementsByTagName(
@@ -720,6 +837,7 @@ describe("Helmet - Declarative API", () => {
 
                 Object.keys(attributeList).forEach(attribute => {
                     it(attribute, done => {
+                        const store = createHelmetStore();
                         const attrValue = attributeList[attribute];
 
                         const attr = {
@@ -727,9 +845,11 @@ describe("Helmet - Declarative API", () => {
                         };
 
                         ReactDOM.render(
-                            <Helmet>
-                                <body {...attr} />
-                            </Helmet>,
+                            <HelmetProvider store={store}>
+                                <Helmet>
+                                    <body {...attr} />
+                                </Helmet>
+                            </HelmetProvider>,
                             container
                         );
 
@@ -752,10 +872,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates multiple body attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <body className="myClassName" tabIndex={-1} />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <body className="myClassName" tabIndex={-1} />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -775,15 +898,18 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets attributes based on the deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <body lang="en" />
-                        </Helmet>
-                        <Helmet>
-                            <body lang="ja" />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <body lang="en" />
+                            </Helmet>
+                            <Helmet>
+                                <body lang="ja" />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -800,10 +926,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("handles valueless attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <body hidden />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <body hidden />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -820,15 +949,23 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears body attributes that are handled within helmet", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <body lang="en" hidden />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <body lang="en" hidden />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const bodyTag = document.body;
@@ -845,18 +982,27 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates with multiple additions and removals - overwrite and new", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <body lang="en" hidden />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <body lang="en" hidden />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
                     ReactDOM.render(
-                        <Helmet>
-                            <body lang="ja" id="body-tag" title="body tag" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <body
+                                    lang="ja"
+                                    id="body-tag"
+                                    title="body tag"
+                                />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
@@ -879,18 +1025,23 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("updates with multiple additions and removals - all new", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <body lang="en" hidden />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <body lang="en" hidden />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
                     ReactDOM.render(
-                        <Helmet>
-                            <body id="body-tag" title="body tag" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <body id="body-tag" title="body tag" />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
@@ -919,7 +1070,13 @@ describe("Helmet - Declarative API", () => {
                 });
 
                 it("attributes are not cleared", done => {
-                    ReactDOM.render(<Helmet />, container);
+                    const store = createHelmetStore();
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const bodyTag = document.body;
@@ -934,10 +1091,13 @@ describe("Helmet - Declarative API", () => {
                 });
 
                 it("attributes are overwritten if specified in helmet", done => {
+                    const store = createHelmetStore();
                     ReactDOM.render(
-                        <Helmet>
-                            <body test="helmet-attr" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <body test="helmet-attr" />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
@@ -956,15 +1116,23 @@ describe("Helmet - Declarative API", () => {
                 });
 
                 it("attributes are cleared once managed in helmet", done => {
+                    const store = createHelmetStore();
                     ReactDOM.render(
-                        <Helmet>
-                            <body test="helmet-attr" />
-                        </Helmet>,
+                        <HelmetProvider store={store}>
+                            <Helmet>
+                                <body test="helmet-attr" />
+                            </Helmet>
+                        </HelmetProvider>,
                         container
                     );
 
                     requestAnimationFrame(() => {
-                        ReactDOM.render(<Helmet />, container);
+                        ReactDOM.render(
+                            <HelmetProvider store={store}>
+                                <Helmet />
+                            </HelmetProvider>,
+                            container
+                        );
 
                         requestAnimationFrame(() => {
                             const bodyTag = document.body;
@@ -983,23 +1151,26 @@ describe("Helmet - Declarative API", () => {
 
         describe("onChangeClientState", () => {
             it("when handling client state change, calls the function with new state, addedTags and removedTags ", done => {
+                const store = createHelmetStore();
                 const spy = sinon.spy();
                 ReactDOM.render(
-                    <div>
-                        <Helmet onChangeClientState={spy}>
-                            <base href="http://mysite.com/" />
-                            <link
-                                href="http://localhost/helmet"
-                                rel="canonical"
-                            />
-                            <meta charSet="utf-8" />
-                            <script
-                                src="http://localhost/test.js"
-                                type="text/javascript"
-                            />
-                            <title>Main Title</title>
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet onChangeClientState={spy}>
+                                <base href="http://mysite.com/" />
+                                <link
+                                    href="http://localhost/helmet"
+                                    rel="canonical"
+                                />
+                                <meta charSet="utf-8" />
+                                <script
+                                    src="http://localhost/test.js"
+                                    type="text/javascript"
+                                />
+                                <title>Main Title</title>
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1054,16 +1225,19 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("calls the deepest defined callback with the deepest state", done => {
+                const store = createHelmetStore();
                 const spy = sinon.spy();
                 ReactDOM.render(
-                    <div>
-                        <Helmet onChangeClientState={spy}>
-                            <title>Main Title</title>
-                        </Helmet>
-                        <Helmet>
-                            <title>Deeper Title</title>
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet onChangeClientState={spy}>
+                                <title>Main Title</title>
+                            </Helmet>
+                            <Helmet>
+                                <title>Deeper Title</title>
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1080,10 +1254,13 @@ describe("Helmet - Declarative API", () => {
 
         describe("base tag", () => {
             it("updates base tag", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <base href="http://mysite.com/" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <base href="http://mysite.com/" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1110,13 +1287,21 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears the base tag if one is not specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet base={{href: "http://mysite.com/"}} />,
+                    <HelmetProvider store={store}>
+                        <Helmet base={{href: "http://mysite.com/"}} />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -1132,10 +1317,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags without 'href' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <base property="won't work" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <base property="won't work" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1152,15 +1340,18 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets base tag based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <base href="http://mysite.com" />
-                        </Helmet>
-                        <Helmet>
-                            <base href="http://mysite.com/public" />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <base href="http://mysite.com" />
+                            </Helmet>
+                            <Helmet>
+                                <base href="http://mysite.com/public" />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1192,10 +1383,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <base href={undefined} />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <base href={undefined} />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1213,14 +1407,26 @@ describe("Helmet - Declarative API", () => {
 
         describe("meta tags", () => {
             it("updates meta tags", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <meta charSet="utf-8" />
-                        <meta name="description" content="Test description" />
-                        <meta httpEquiv="content-type" content="text/html" />
-                        <meta property="og:type" content="article" />
-                        <meta itemProp="name" content="Test name itemprop" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <meta charSet="utf-8" />
+                            <meta
+                                name="description"
+                                content="Test description"
+                            />
+                            <meta
+                                httpEquiv="content-type"
+                                content="text/html"
+                            />
+                            <meta property="og:type" content="article" />
+                            <meta
+                                itemProp="name"
+                                content="Test name itemprop"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1257,15 +1463,26 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears all meta tags if none are specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <meta name="description" content="Test description" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <meta
+                                name="description"
+                                content="Test description"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -1281,10 +1498,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags without 'name', 'http-equiv', 'property', 'charset', or 'itemprop' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <meta href="won't work" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <meta href="won't work" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1301,23 +1521,29 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets meta tags based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <meta charSet="utf-8" />
-                            <meta
-                                name="description"
-                                content="Test description"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <meta
-                                name="description"
-                                content="Inner description"
-                            />
-                            <meta name="keywords" content="test,meta,tags" />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <meta charSet="utf-8" />
+                                <meta
+                                    name="description"
+                                    content="Test description"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <meta
+                                    name="description"
+                                    content="Inner description"
+                                />
+                                <meta
+                                    name="keywords"
+                                    content="test,meta,tags"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1375,14 +1601,20 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("allows duplicate meta tags if specified in the same component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <meta name="description" content="Test description" />
-                        <meta
-                            name="description"
-                            content="Duplicate description"
-                        />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <meta
+                                name="description"
+                                content="Test description"
+                            />
+                            <meta
+                                name="description"
+                                content="Duplicate description"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1431,25 +1663,28 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("overrides duplicate meta tags with single meta tag in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <meta
-                                name="description"
-                                content="Test description"
-                            />
-                            <meta
-                                name="description"
-                                content="Duplicate description"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <meta
-                                name="description"
-                                content="Inner description"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <meta
+                                    name="description"
+                                    content="Test description"
+                                />
+                                <meta
+                                    name="description"
+                                    content="Duplicate description"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <meta
+                                    name="description"
+                                    content="Inner description"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1483,25 +1718,28 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("overrides single meta tag with duplicate meta tags in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <meta
-                                name="description"
-                                content="Test description"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <meta
-                                name="description"
-                                content="Inner description"
-                            />
-                            <meta
-                                name="description"
-                                content="Inner duplicate description"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <meta
+                                    name="description"
+                                    content="Test description"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <meta
+                                    name="description"
+                                    content="Inner description"
+                                />
+                                <meta
+                                    name="description"
+                                    content="Inner duplicate description"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1550,13 +1788,16 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <meta
-                            name={undefined}
-                            content="Inner duplicate description"
-                        />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <meta
+                                name={undefined}
+                                content="Inner duplicate description"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1574,15 +1815,21 @@ describe("Helmet - Declarative API", () => {
 
         describe("link tags", () => {
             it("updates link tags", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <link href="http://localhost/helmet" rel="canonical" />
-                        <link
-                            href="http://localhost/style.css"
-                            rel="stylesheet"
-                            type="text/css"
-                        />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <link
+                                href="http://localhost/helmet"
+                                rel="canonical"
+                            />
+                            <link
+                                href="http://localhost/style.css"
+                                rel="stylesheet"
+                                type="text/css"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1615,15 +1862,26 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears all link tags if none are specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <link href="http://localhost/helmet" rel="canonical" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <link
+                                href="http://localhost/helmet"
+                                rel="canonical"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const tagNodes = headElement.querySelectorAll(
@@ -1642,10 +1900,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags without 'href' or 'rel' are not accepted, even if they are valid for other tags", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <link httpEquiv="won't work" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <link httpEquiv="won't work" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1663,27 +1924,30 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags 'rel' and 'href' properly use 'rel' as the primary identification for this tag, regardless of ordering", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <link
-                                href="http://localhost/helmet"
-                                rel="canonical"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet/new"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <link
-                                href="http://localhost/helmet/newest"
-                                rel="canonical"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <link
+                                    href="http://localhost/helmet"
+                                    rel="canonical"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet/new"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <link
+                                    href="http://localhost/helmet/newest"
+                                    rel="canonical"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1715,25 +1979,28 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags with rel='stylesheet' uses the href as the primary identification of the tag, regardless of ordering", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <link
-                                href="http://localhost/style.css"
-                                rel="stylesheet"
-                                type="text/css"
-                                media="all"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <link
-                                rel="stylesheet"
-                                href="http://localhost/inner.css"
-                                type="text/css"
-                                media="all"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <link
+                                    href="http://localhost/style.css"
+                                    rel="stylesheet"
+                                    type="text/css"
+                                    media="all"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <link
+                                    rel="stylesheet"
+                                    href="http://localhost/inner.css"
+                                    type="text/css"
+                                    media="all"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1784,33 +2051,36 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets link tags based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet"
-                            />
-                            <link
-                                href="http://localhost/style.css"
-                                rel="stylesheet"
-                                type="text/css"
-                                media="all"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet/innercomponent"
-                            />
-                            <link
-                                href="http://localhost/inner.css"
-                                rel="stylesheet"
-                                type="text/css"
-                                media="all"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet"
+                                />
+                                <link
+                                    href="http://localhost/style.css"
+                                    rel="stylesheet"
+                                    type="text/css"
+                                    media="all"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet/innercomponent"
+                                />
+                                <link
+                                    href="http://localhost/inner.css"
+                                    rel="stylesheet"
+                                    type="text/css"
+                                    media="all"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1872,14 +2142,20 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("allows duplicate link tags if specified in the same component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <link rel="canonical" href="http://localhost/helmet" />
-                        <link
-                            rel="canonical"
-                            href="http://localhost/helmet/component"
-                        />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <link
+                                rel="canonical"
+                                href="http://localhost/helmet"
+                            />
+                            <link
+                                rel="canonical"
+                                href="http://localhost/helmet/component"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1924,25 +2200,28 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("overrides duplicate link tags with a single link tag in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet"
-                            />
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet/component"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet/innercomponent"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet"
+                                />
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet/component"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet/innercomponent"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1974,25 +2253,28 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("overrides single link tag with duplicate link tags in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet"
-                            />
-                        </Helmet>
-                        <Helmet>
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet/component"
-                            />
-                            <link
-                                rel="canonical"
-                                href="http://localhost/helmet/innercomponent"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet"
+                                />
+                            </Helmet>
+                            <Helmet>
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet/component"
+                                />
+                                <link
+                                    rel="canonical"
+                                    href="http://localhost/helmet/innercomponent"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2037,14 +2319,17 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <link rel="icon" sizes="192x192" href={null} />
-                        <link
-                            rel="canonical"
-                            href="http://localhost/helmet/component"
-                        />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <link rel="icon" sizes="192x192" href={null} />
+                            <link
+                                rel="canonical"
+                                href="http://localhost/helmet/component"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2077,6 +2362,7 @@ describe("Helmet - Declarative API", () => {
 
         describe("script tags", () => {
             it("updates script tags", done => {
+                const store = createHelmetStore();
                 const scriptInnerHTML = `
                   {
                     "@context": "http://schema.org",
@@ -2085,19 +2371,21 @@ describe("Helmet - Declarative API", () => {
                   }
                 `;
                 ReactDOM.render(
-                    <Helmet>
-                        <script
-                            src="http://localhost/test.js"
-                            type="text/javascript"
-                        />
-                        <script
-                            src="http://localhost/test2.js"
-                            type="text/javascript"
-                        />
-                        <script type="application/ld+json">
-                            {scriptInnerHTML}
-                        </script>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <script
+                                src="http://localhost/test.js"
+                                type="text/javascript"
+                            />
+                            <script
+                                src="http://localhost/test2.js"
+                                type="text/javascript"
+                            />
+                            <script type="application/ld+json">
+                                {scriptInnerHTML}
+                            </script>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2133,18 +2421,26 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears all scripts tags if none are specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <script
-                            src="http://localhost/test.js"
-                            type="text/javascript"
-                        />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <script
+                                src="http://localhost/test.js"
+                                type="text/javascript"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -2160,10 +2456,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags without 'src' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <script property="won't work" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <script property="won't work" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2180,19 +2479,22 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets script tags based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet>
-                            <script
-                                src="http://localhost/test.js"
-                                type="text/javascript"
-                            />
-                            <script
-                                src="http://localhost/test2.js"
-                                type="text/javascript"
-                            />
-                        </Helmet>
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet>
+                                <script
+                                    src="http://localhost/test.js"
+                                    type="text/javascript"
+                                />
+                                <script
+                                    src="http://localhost/test2.js"
+                                    type="text/javascript"
+                                />
+                            </Helmet>
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2241,10 +2543,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("sets undefined attribute values to empty strings", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <script src="foo.js" async={undefined} />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <script src="foo.js" async={undefined} />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2265,10 +2570,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not render tag when primary attribute (src) is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <script src={undefined} type="text/javascript" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <script src={undefined} type="text/javascript" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2284,10 +2592,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not render tag when primary attribute (innerHTML) is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <script innerHTML={undefined} />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <script innerHTML={undefined} />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2305,11 +2616,14 @@ describe("Helmet - Declarative API", () => {
 
         describe("noscript tags", () => {
             it("updates noscript tags", done => {
+                const store = createHelmetStore();
                 const noscriptInnerHTML = `<link rel="stylesheet" type="text/css" href="foo.css" />`;
                 ReactDOM.render(
-                    <Helmet>
-                        <noscript id="bar">{noscriptInnerHTML}</noscript>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <noscript id="bar">{noscriptInnerHTML}</noscript>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2330,15 +2644,23 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears all noscripts tags if none are specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <noscript id="bar" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <noscript id="bar" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -2354,10 +2676,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags without 'innerHTML' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <noscript property="won't work" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <noscript property="won't work" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2374,10 +2699,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <noscript>{undefined}</noscript>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <noscript>{undefined}</noscript>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2395,6 +2723,7 @@ describe("Helmet - Declarative API", () => {
 
         describe("style tags", () => {
             it("updates style tags", done => {
+                const store = createHelmetStore();
                 const cssText1 = `
                     body {
                         background-color: green;
@@ -2407,10 +2736,12 @@ describe("Helmet - Declarative API", () => {
                 `;
 
                 ReactDOM.render(
-                    <Helmet>
-                        <style type="text/css">{cssText1}</style>
-                        <style>{cssText2}</style>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <style type="text/css">{cssText1}</style>
+                            <style>{cssText2}</style>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2447,20 +2778,28 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("clears all style tags if none are specified", done => {
+                const store = createHelmetStore();
                 const cssText = `
                     body {
                         background-color: green;
                     }
                 `;
                 ReactDOM.render(
-                    <Helmet>
-                        <style type="text/css">{cssText}</style>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <style type="text/css">{cssText}</style>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -2476,10 +2815,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("tags without 'cssText' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <style property="won't work" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <style property="won't work" />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2496,10 +2838,13 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <style>{undefined}</style>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <style>{undefined}</style>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2526,19 +2871,18 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("executes synchronously when defer={true} and async otherwise", done => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <div>
-                    <Helmet defer={false}>
-                        <script>
-                            window.__spy__(1)
-                        </script>
-                    </Helmet>
-                    <Helmet>
-                        <script>
-                            window.__spy__(2)
-                        </script>
-                    </Helmet>
-                </div>,
+                <HelmetProvider store={store}>
+                    <div>
+                        <Helmet defer={false}>
+                            <script>window.__spy__(1)</script>
+                        </Helmet>
+                        <Helmet>
+                            <script>window.__spy__(2)</script>
+                        </Helmet>
+                    </div>
+                </HelmetProvider>,
                 container
             );
 
@@ -2594,8 +2938,9 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("provides initial values if no state is found", () => {
-            let head = Helmet.rewind();
-            head = Helmet.rewind();
+            const store = createHelmetStore();
+            let head = store.renderStatic();
+            head = store.renderStatic();
 
             expect(head.meta).to.exist;
             expect(head.meta).to.respondTo("toString");
@@ -2604,14 +2949,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("encodes special characters in title", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <title>{`Dangerous <script> include`}</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title>{`Dangerous <script> include`}</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2620,14 +2968,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("opts out of string encoding", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet encodeSpecialCharacters={false}>
-                    <title>{"This is text and & and '."}</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet encodeSpecialCharacters={false}>
+                        <title>{"This is text and & and '."}</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
 
@@ -2635,14 +2986,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders title as React component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <title>{`Dangerous <script> include`}</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title>{`Dangerous <script> include`}</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toComponent");
@@ -2658,9 +3012,7 @@ describe("Helmet - Declarative API", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {titleComponent}
-                </div>
+                <div>{titleComponent}</div>
             );
 
             expect(markup).to.be
@@ -2669,14 +3021,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders title with itemprop name as React component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <title itemProp="name">Title with Itemprop</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title itemProp="name">Title with Itemprop</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toComponent");
@@ -2692,9 +3047,7 @@ describe("Helmet - Declarative API", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {titleComponent}
-                </div>
+                <div>{titleComponent}</div>
             );
 
             expect(markup).to.be
@@ -2703,14 +3056,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders base tag as React component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <base target="_blank" href="http://localhost/" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <base target="_blank" href="http://localhost/" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.base).to.exist;
             expect(head.base).to.respondTo("toComponent");
@@ -2726,9 +3082,7 @@ describe("Helmet - Declarative API", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {baseComponent}
-                </div>
+                <div>{baseComponent}</div>
             );
 
             expect(markup).to.be
@@ -2737,23 +3091,26 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders meta tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <meta charSet="utf-8" />
-                    <meta
-                        name="description"
-                        content={
-                            "Test description & encoding of special characters like ' \" > < `"
-                        }
-                    />
-                    <meta httpEquiv="content-type" content="text/html" />
-                    <meta property="og:type" content="article" />
-                    <meta itemProp="name" content="Test name itemprop" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <meta charSet="utf-8" />
+                        <meta
+                            name="description"
+                            content={
+                                "Test description & encoding of special characters like ' \" > < `"
+                            }
+                        />
+                        <meta httpEquiv="content-type" content="text/html" />
+                        <meta property="og:type" content="article" />
+                        <meta itemProp="name" content="Test name itemprop" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.meta).to.exist;
             expect(head.meta).to.respondTo("toComponent");
@@ -2769,9 +3126,7 @@ describe("Helmet - Declarative API", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {metaComponent}
-                </div>
+                <div>{metaComponent}</div>
             );
 
             expect(markup).to.be
@@ -2780,19 +3135,22 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders link tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <link href="http://localhost/helmet" rel="canonical" />
-                    <link
-                        href="http://localhost/style.css"
-                        rel="stylesheet"
-                        type="text/css"
-                    />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <link href="http://localhost/helmet" rel="canonical" />
+                        <link
+                            href="http://localhost/style.css"
+                            rel="stylesheet"
+                            type="text/css"
+                        />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.link).to.exist;
             expect(head.link).to.respondTo("toComponent");
@@ -2808,9 +3166,7 @@ describe("Helmet - Declarative API", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {linkComponent}
-                </div>
+                <div>{linkComponent}</div>
             );
 
             expect(markup).to.be
@@ -2819,21 +3175,24 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders script tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <script
-                        src="http://localhost/test.js"
-                        type="text/javascript"
-                    />
-                    <script
-                        src="http://localhost/test2.js"
-                        type="text/javascript"
-                    />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <script
+                            src="http://localhost/test.js"
+                            type="text/javascript"
+                        />
+                        <script
+                            src="http://localhost/test2.js"
+                            type="text/javascript"
+                        />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.script).to.exist;
             expect(head.script).to.respondTo("toComponent");
@@ -2849,9 +3208,7 @@ describe("Helmet - Declarative API", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {scriptComponent}
-                </div>
+                <div>{scriptComponent}</div>
             );
 
             expect(markup).to.be
@@ -2860,15 +3217,18 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders noscript tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <noscript id="foo">{`<link rel="stylesheet" type="text/css" href="/style.css" />`}</noscript>
-                    <noscript id="bar">{`<link rel="stylesheet" type="text/css" href="/style2.css" />`}</noscript>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <noscript id="foo">{`<link rel="stylesheet" type="text/css" href="/style.css" />`}</noscript>
+                        <noscript id="bar">{`<link rel="stylesheet" type="text/css" href="/style2.css" />`}</noscript>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.noscript).to.exist;
             expect(head.noscript).to.respondTo("toComponent");
@@ -2884,9 +3244,7 @@ describe("Helmet - Declarative API", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {noscriptComponent}
-                </div>
+                <div>{noscriptComponent}</div>
             );
 
             expect(markup).to.be
@@ -2895,15 +3253,18 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders style tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <style type="text/css">{`body {background-color: green;}`}</style>
-                    <style type="text/css">{`p {font-size: 12px;}`}</style>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <style type="text/css">{`body {background-color: green;}`}</style>
+                        <style type="text/css">{`p {font-size: 12px;}`}</style>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.style).to.exist;
             expect(head.style).to.respondTo("toComponent");
@@ -2913,9 +3274,7 @@ describe("Helmet - Declarative API", () => {
             expect(styleComponent).to.be.an("array").that.has.length.of(2);
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {styleComponent}
-                </div>
+                <div>{styleComponent}</div>
             );
 
             expect(markup).to.be
@@ -2924,14 +3283,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders title tag as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <title>{"Dangerous <script> include"}</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title>{"Dangerous <script> include"}</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2942,16 +3304,19 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders title and allows children containing expressions", done => {
+            const store = createHelmetStore();
             const someValue = "Some Great Title";
 
             ReactDOM.render(
-                <Helmet>
-                    <title>Title: {someValue}</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title>Title: {someValue}</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2966,14 +3331,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders title with itemprop name as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <title itemProp="name">Title with Itemprop</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title itemProp="name">Title with Itemprop</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2985,14 +3353,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders base tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <base target="_blank" href="http://localhost/" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <base target="_blank" href="http://localhost/" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.base).to.exist;
             expect(head.base).to.respondTo("toString");
@@ -3003,21 +3374,24 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders meta tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <meta charSet="utf-8" />
-                    <meta
-                        name="description"
-                        content="Test description &amp; encoding of special characters like &#x27; &quot; &gt; &lt; `"
-                    />
-                    <meta httpEquiv="content-type" content="text/html" />
-                    <meta property="og:type" content="article" />
-                    <meta itemProp="name" content="Test name itemprop" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <meta charSet="utf-8" />
+                        <meta
+                            name="description"
+                            content="Test description &amp; encoding of special characters like &#x27; &quot; &gt; &lt; `"
+                        />
+                        <meta httpEquiv="content-type" content="text/html" />
+                        <meta property="og:type" content="article" />
+                        <meta itemProp="name" content="Test name itemprop" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.meta).to.exist;
             expect(head.meta).to.respondTo("toString");
@@ -3028,19 +3402,22 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders link tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <link href="http://localhost/helmet" rel="canonical" />
-                    <link
-                        href="http://localhost/style.css"
-                        rel="stylesheet"
-                        type="text/css"
-                    />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <link href="http://localhost/helmet" rel="canonical" />
+                        <link
+                            href="http://localhost/style.css"
+                            rel="stylesheet"
+                            type="text/css"
+                        />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.link).to.exist;
             expect(head.link).to.respondTo("toString");
@@ -3051,21 +3428,24 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders script tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <script
-                        src="http://localhost/test.js"
-                        type="text/javascript"
-                    />
-                    <script
-                        src="http://localhost/test2.js"
-                        type="text/javascript"
-                    />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <script
+                            src="http://localhost/test.js"
+                            type="text/javascript"
+                        />
+                        <script
+                            src="http://localhost/test2.js"
+                            type="text/javascript"
+                        />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.script).to.exist;
             expect(head.script).to.respondTo("toString");
@@ -3076,15 +3456,18 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders style tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <style type="text/css">{`body {background-color: green;}`}</style>
-                    <style type="text/css">{`p {font-size: 12px;}`}</style>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <style type="text/css">{`body {background-color: green;}`}</style>
+                        <style type="text/css">{`p {font-size: 12px;}`}</style>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.style).to.exist;
             expect(head.style).to.respondTo("toString");
@@ -3095,14 +3478,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders html attributes as component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <html lang="ga" className="myClassName" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <html lang="ga" className="myClassName" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const {htmlAttributes} = Helmet.rewind();
+            const {htmlAttributes} = store.renderStatic();
             const attrs = htmlAttributes.toComponent();
 
             expect(attrs).to.exist;
@@ -3117,14 +3503,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders html attributes as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <html lang="ga" className="myClassName" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <html lang="ga" className="myClassName" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.htmlAttributes).to.exist;
             expect(head.htmlAttributes).to.respondTo("toString");
@@ -3135,14 +3524,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders body attributes as component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <body lang="ga" className="myClassName" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <body lang="ga" className="myClassName" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const {bodyAttributes} = Helmet.rewind();
+            const {bodyAttributes} = store.renderStatic();
             const attrs = bodyAttributes.toComponent();
 
             expect(attrs).to.exist;
@@ -3157,14 +3549,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("renders body attributes as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <body lang="ga" className="myClassName" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <body lang="ga" className="myClassName" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const body = Helmet.rewind();
+            const body = store.renderStatic();
 
             expect(body.bodyAttributes).to.exist;
             expect(body.bodyAttributes).to.respondTo("toString");
@@ -3175,19 +3570,22 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("does not encode all characters with HTML character entity equivalents", () => {
+            const store = createHelmetStore();
             const chineseTitle = "膣膗 鍆錌雔";
             const stringifiedChineseTitle = `<title ${HELMET_ATTRIBUTE}="true">${chineseTitle}</title>`;
 
             ReactDOM.render(
-                <div>
-                    <Helmet>
-                        <title>{chineseTitle}</title>
-                    </Helmet>
-                </div>,
+                <HelmetProvider store={store}>
+                    <div>
+                        <Helmet>
+                            <title>{chineseTitle}</title>
+                        </Helmet>
+                    </div>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -3197,10 +3595,11 @@ describe("Helmet - Declarative API", () => {
                 .that.equals(stringifiedChineseTitle);
         });
 
-        it("rewind() provides a fallback object for empty Helmet state", () => {
+        it("renderStatic() provides a fallback object for empty Helmet state", () => {
+            const store = createHelmetStore();
             ReactDOM.render(<div />, container);
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.htmlAttributes).to.exist;
             expect(head.htmlAttributes).to.respondTo("toString");
@@ -3217,9 +3616,7 @@ describe("Helmet - Declarative API", () => {
             expect(head.title).to.respondTo("toComponent");
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {head.title.toComponent()}
-                </div>
+                <div>{head.title.toComponent()}</div>
             );
 
             expect(markup).to.be
@@ -3266,14 +3663,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("does not render undefined attribute values", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <script src="foo.js" async={undefined} />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <script src="foo.js" async={undefined} />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
-            const {script} = Helmet.rewind();
+            const {script} = store.renderStatic();
             const stringifiedScriptTag = script.toString();
 
             expect(stringifiedScriptTag).to.be
@@ -3285,14 +3685,17 @@ describe("Helmet - Declarative API", () => {
 
         context("renderStatic", () => {
             it("does html encode title", () => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <title>{`Dangerous <script> include`}</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title>{`Dangerous <script> include`}</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
-                const head = Helmet.renderStatic();
+                const head = store.renderStatic();
 
                 expect(head.title).to.exist;
                 expect(head.title).to.respondTo("toString");
@@ -3301,14 +3704,17 @@ describe("Helmet - Declarative API", () => {
             });
 
             it("renders title as React component", () => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet>
-                        <title>{`Dangerous <script> include`}</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title>{`Dangerous <script> include`}</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
-                const head = Helmet.renderStatic();
+                const head = store.renderStatic();
 
                 expect(head.title).to.exist;
                 expect(head.title).to.respondTo("toComponent");
@@ -3324,9 +3730,7 @@ describe("Helmet - Declarative API", () => {
                 });
 
                 const markup = ReactServer.renderToStaticMarkup(
-                    <div>
-                        {titleComponent}
-                    </div>
+                    <div>{titleComponent}</div>
                 );
 
                 expect(markup).to.be
@@ -3341,31 +3745,21 @@ describe("Helmet - Declarative API", () => {
     });
 
     describe("misc", () => {
-        it("throws in rewind() when a DOM is present", () => {
-            ReactDOM.render(
-                <Helmet>
-                    <title>Fancy title</title>
-                </Helmet>,
-                container
-            );
-
-            expect(Helmet.rewind).to.throw(
-                "You may only call rewind() on the server. Call peek() to read the current state."
-            );
-        });
-
         it("lets you read current state in peek() whether or not a DOM is present", done => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <title>Fancy title</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title>Fancy title</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
             requestAnimationFrame(() => {
-                expect(Helmet.peek().title).to.be.equal("Fancy title");
+                expect(store.peek().title).to.be.equal("Fancy title");
                 Helmet.canUseDOM = false;
-                expect(Helmet.peek().title).to.be.equal("Fancy title");
+                expect(store.peek().title).to.be.equal("Fancy title");
                 Helmet.canUseDOM = true;
 
                 done();
@@ -3373,13 +3767,16 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("encodes special characters", done => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <meta
-                        name="description"
-                        content={'This is "quoted" text and & and \'.'}
-                    />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <meta
+                            name="description"
+                            content={'This is "quoted" text and & and \'.'}
+                        />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
@@ -3412,22 +3809,30 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("does not change the DOM if it recevies identical props", done => {
+            const store = createHelmetStore();
             const spy = sinon.spy();
             ReactDOM.render(
-                <Helmet onChangeClientState={spy}>
-                    <meta name="description" content="Test description" />
-                    <title>Test Title</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet onChangeClientState={spy}>
+                        <meta name="description" content="Test description" />
+                        <title>Test Title</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
             requestAnimationFrame(() => {
                 // Re-rendering will pass new props to an already mounted Helmet
                 ReactDOM.render(
-                    <Helmet onChangeClientState={spy}>
-                        <meta name="description" content="Test description" />
-                        <title>Test Title</title>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet onChangeClientState={spy}>
+                            <meta
+                                name="description"
+                                content="Test description"
+                            />
+                            <title>Test Title</title>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -3440,16 +3845,19 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("does not write the DOM if the client and server are identical", done => {
+            const store = createHelmetStore();
             headElement.innerHTML = `<script ${HELMET_ATTRIBUTE}="true" src="http://localhost/test.js" type="text/javascript" />`;
 
             const spy = sinon.spy();
             ReactDOM.render(
-                <Helmet onChangeClientState={spy}>
-                    <script
-                        src="http://localhost/test.js"
-                        type="text/javascript"
-                    />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet onChangeClientState={spy}>
+                        <script
+                            src="http://localhost/test.js"
+                            type="text/javascript"
+                        />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
@@ -3466,18 +3874,21 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("only adds new tags and preserves tags when rendering additional Helmet instances", done => {
+            const store = createHelmetStore();
             const spy = sinon.spy();
             let addedTags;
             let removedTags;
             ReactDOM.render(
-                <Helmet onChangeClientState={spy}>
-                    <link
-                        href="http://localhost/style.css"
-                        rel="stylesheet"
-                        type="text/css"
-                    />
-                    <meta name="description" content="Test description" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet onChangeClientState={spy}>
+                        <link
+                            href="http://localhost/style.css"
+                            rel="stylesheet"
+                            type="text/css"
+                        />
+                        <meta name="description" content="Test description" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
@@ -3500,19 +3911,24 @@ describe("Helmet - Declarative API", () => {
 
                 // Re-rendering will pass new props to an already mounted Helmet
                 ReactDOM.render(
-                    <Helmet onChangeClientState={spy}>
-                        <link
-                            href="http://localhost/style.css"
-                            rel="stylesheet"
-                            type="text/css"
-                        />
-                        <link
-                            href="http://localhost/style2.css"
-                            rel="stylesheet"
-                            type="text/css"
-                        />
-                        <meta name="description" content="New description" />
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet onChangeClientState={spy}>
+                            <link
+                                href="http://localhost/style.css"
+                                rel="stylesheet"
+                                type="text/css"
+                            />
+                            <link
+                                href="http://localhost/style2.css"
+                                rel="stylesheet"
+                                type="text/css"
+                            />
+                            <meta
+                                name="description"
+                                content="New description"
+                            />
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -3544,15 +3960,18 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("does not accept nested Helmets", done => {
+            const store = createHelmetStore();
             const warn = sinon.stub(console, "warn");
 
             ReactDOM.render(
-                <Helmet>
-                    <title>Test Title</title>
+                <HelmetProvider store={store}>
                     <Helmet>
-                        <title>Title you will never see</title>
+                        <title>Test Title</title>
+                        <Helmet>
+                            <title>Title you will never see</title>
+                        </Helmet>
                     </Helmet>
-                </Helmet>,
+                </HelmetProvider>,
                 container
             );
 
@@ -3572,15 +3991,18 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("warns on invalid elements", done => {
+            const store = createHelmetStore();
             const warn = sinon.stub(console, "warn");
 
             ReactDOM.render(
-                <Helmet>
-                    <title>Test Title</title>
-                    <div>
-                        <title>Title you will never see</title>
-                    </div>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title>Test Title</title>
+                        <div>
+                            <title>Title you will never see</title>
+                        </div>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
@@ -3599,13 +4021,16 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("warns on invalid self-closing elements", done => {
+            const store = createHelmetStore();
             const warn = sinon.stub(console, "warn");
 
             ReactDOM.render(
-                <Helmet>
-                    <title>Test Title</title>
-                    <div customAttribute={true} />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <title>Test Title</title>
+                        <div customAttribute={true} />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
@@ -3624,15 +4049,18 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("throws on invalid strings as children", () => {
+            const store = createHelmetStore();
             const renderInvalid = () =>
                 ReactDOM.render(
-                    <Helmet>
-                        <title>Test Title</title>
-                        <link
-                            href="http://localhost/helmet"
-                            rel="canonical"
-                        >{`test`}</link>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title>Test Title</title>
+                            <link
+                                href="http://localhost/helmet"
+                                rel="canonical"
+                            >{`test`}</link>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -3643,14 +4071,17 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("throws on invalid children", () => {
+            const store = createHelmetStore();
             const renderInvalid = () =>
                 ReactDOM.render(
-                    <Helmet>
-                        <title>Test Title</title>
-                        <script>
-                            <title>Title you will never see</title>
-                        </script>
-                    </Helmet>,
+                    <HelmetProvider store={store}>
+                        <Helmet>
+                            <title>Test Title</title>
+                            <script>
+                                <title>Title you will never see</title>
+                            </script>
+                        </Helmet>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -3661,13 +4092,16 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("handles undefined children", done => {
+            const store = createHelmetStore();
             const charSet = undefined;
 
             ReactDOM.render(
-                <Helmet>
-                    {charSet && <meta charSet={charSet} />}
-                    <title>Test Title</title>
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        {charSet && <meta charSet={charSet} />}
+                        <title>Test Title</title>
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
@@ -3679,10 +4113,13 @@ describe("Helmet - Declarative API", () => {
         });
 
         it("recognizes valid tags regardless of attribute ordering", done => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet>
-                    <meta content="Test Description" name="description" />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet>
+                        <meta content="Test Description" name="description" />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 

--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -4,7 +4,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import ReactServer from "react-dom/server";
-import {Helmet} from "../src/Helmet";
+import {Helmet, HelmetProvider, createHelmetStore} from "../src/Helmet";
 import {requestAnimationFrame} from "../src/HelmetUtils.js";
 
 const HELMET_ATTRIBUTE = "data-react-helmet";
@@ -29,8 +29,14 @@ describe("Helmet", () => {
     describe("api", () => {
         describe("title", () => {
             it("updates page title", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet defaultTitle={"Fallback"} title={"Test Title"} />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            defaultTitle={"Fallback"}
+                            title={"Test Title"}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -42,12 +48,15 @@ describe("Helmet", () => {
             });
 
             it("updates page title with multiple children", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet title={"Test Title"} />
-                        <Helmet title={"Child One Title"} />
-                        <Helmet title={"Child Two Title"} />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet title={"Test Title"} />
+                            <Helmet title={"Child One Title"} />
+                            <Helmet title={"Child Two Title"} />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -59,11 +68,14 @@ describe("Helmet", () => {
             });
 
             it("sets title based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet title={"Main Title"} />
-                        <Helmet title={"Nested Title"} />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet title={"Main Title"} />
+                            <Helmet title={"Nested Title"} />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -75,11 +87,14 @@ describe("Helmet", () => {
             });
 
             it("sets title using deepest nested component with a defined title", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet title={"Main Title"} />
-                        <Helmet />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet title={"Main Title"} />
+                            <Helmet />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -91,14 +106,17 @@ describe("Helmet", () => {
             });
 
             it("uses defaultTitle if no title is defined", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        defaultTitle={"Fallback"}
-                        title={""}
-                        titleTemplate={
-                            "This is a %s of the titleTemplate feature"
-                        }
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            defaultTitle={"Fallback"}
+                            title={""}
+                            titleTemplate={
+                                "This is a %s of the titleTemplate feature"
+                            }
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -110,14 +128,17 @@ describe("Helmet", () => {
             });
 
             it("uses a titleTemplate if defined", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        defaultTitle={"Fallback"}
-                        title={"Test"}
-                        titleTemplate={
-                            "This is a %s of the titleTemplate feature"
-                        }
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            defaultTitle={"Fallback"}
+                            title={"Test"}
+                            titleTemplate={
+                                "This is a %s of the titleTemplate feature"
+                            }
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -131,13 +152,16 @@ describe("Helmet", () => {
             });
 
             it("replaces multiple title strings in titleTemplate", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        title={"Test"}
-                        titleTemplate={
-                            "This is a %s of the titleTemplate feature. Another %s."
-                        }
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            title={"Test"}
+                            titleTemplate={
+                                "This is a %s of the titleTemplate feature. Another %s."
+                            }
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -151,21 +175,24 @@ describe("Helmet", () => {
             });
 
             it("uses a titleTemplate based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            title={"Test"}
-                            titleTemplate={
-                                "This is a %s of the titleTemplate feature"
-                            }
-                        />
-                        <Helmet
-                            title={"Second Test"}
-                            titleTemplate={
-                                "A %s using nested titleTemplate attributes"
-                            }
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                title={"Test"}
+                                titleTemplate={
+                                    "This is a %s of the titleTemplate feature"
+                                }
+                            />
+                            <Helmet
+                                title={"Second Test"}
+                                titleTemplate={
+                                    "A %s using nested titleTemplate attributes"
+                                }
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -179,16 +206,19 @@ describe("Helmet", () => {
             });
 
             it("merges deepest component title with nearest upstream titleTemplate", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            title={"Test"}
-                            titleTemplate={
-                                "This is a %s of the titleTemplate feature"
-                            }
-                        />
-                        <Helmet title={"Second Test"} />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                title={"Test"}
+                                titleTemplate={
+                                    "This is a %s of the titleTemplate feature"
+                                }
+                            />
+                            <Helmet title={"Second Test"} />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -202,13 +232,16 @@ describe("Helmet", () => {
             });
 
             it("renders dollar characters in a title correctly when titleTemplate present", done => {
+                const store = createHelmetStore();
                 const dollarTitle = "te$t te$$t te$$$t te$$$$t";
 
                 ReactDOM.render(
-                    <Helmet
-                        title={dollarTitle}
-                        titleTemplate={"This is a %s"}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            title={dollarTitle}
+                            titleTemplate={"This is a %s"}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -222,12 +255,15 @@ describe("Helmet", () => {
             });
 
             it("does not encode all characters with HTML character entity equivalents", done => {
+                const store = createHelmetStore();
                 const chineseTitle = "膣膗 鍆錌雔";
 
                 ReactDOM.render(
-                    <div>
-                        <Helmet title={chineseTitle} />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet title={chineseTitle} />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -239,12 +275,15 @@ describe("Helmet", () => {
             });
 
             it("page title with prop itemprop", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        defaultTitle={"Fallback"}
-                        title={"Test Title with itemProp"}
-                        titleAttributes={{itemprop: "name"}}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            defaultTitle={"Fallback"}
+                            title={"Test Title with itemProp"}
+                            titleAttributes={{itemprop: "name"}}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -264,12 +303,15 @@ describe("Helmet", () => {
             });
 
             it("update title attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        titleAttributes={{
-                            itemprop: "name"
-                        }}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            titleAttributes={{
+                                itemprop: "name"
+                            }}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -285,20 +327,23 @@ describe("Helmet", () => {
             });
 
             it("sets attributes based on the deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            titleAttributes={{
-                                lang: "en",
-                                hidden: undefined
-                            }}
-                        />
-                        <Helmet
-                            titleAttributes={{
-                                lang: "ja"
-                            }}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                titleAttributes={{
+                                    lang: "en",
+                                    hidden: undefined
+                                }}
+                            />
+                            <Helmet
+                                titleAttributes={{
+                                    lang: "ja"
+                                }}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -315,12 +360,15 @@ describe("Helmet", () => {
             });
 
             it("handles valueless attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        titleAttributes={{
-                            hidden: undefined
-                        }}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            titleAttributes={{
+                                hidden: undefined
+                            }}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -336,18 +384,26 @@ describe("Helmet", () => {
             });
 
             it("clears title attributes that are handled within helmet", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        titleAttributes={{
-                            lang: "en",
-                            hidden: undefined
-                        }}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            titleAttributes={{
+                                lang: "en",
+                                hidden: undefined
+                            }}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const titleTag = document.getElementsByTagName(
@@ -367,14 +423,17 @@ describe("Helmet", () => {
 
         describe("html attributes", () => {
             it("updates html attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            class: "myClassName",
-                            lang: "en"
-                        }}
-                        lang="en"
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            htmlAttributes={{
+                                class: "myClassName",
+                                lang: "en"
+                            }}
+                            lang="en"
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -393,19 +452,22 @@ describe("Helmet", () => {
             });
 
             it("sets attributes based on the deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            htmlAttributes={{
-                                lang: "en"
-                            }}
-                        />
-                        <Helmet
-                            htmlAttributes={{
-                                lang: "ja"
-                            }}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                htmlAttributes={{
+                                    lang: "en"
+                                }}
+                            />
+                            <Helmet
+                                htmlAttributes={{
+                                    lang: "ja"
+                                }}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -421,12 +483,15 @@ describe("Helmet", () => {
             });
 
             it("handles valueless attributes", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            amp: undefined
-                        }}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            htmlAttributes={{
+                                amp: undefined
+                            }}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -442,18 +507,26 @@ describe("Helmet", () => {
             });
 
             it("clears html attributes that are handled within helmet", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            lang: "en",
-                            amp: undefined
-                        }}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            htmlAttributes={{
+                                lang: "en",
+                                amp: undefined
+                            }}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const htmlTag = document.getElementsByTagName(
@@ -471,25 +544,30 @@ describe("Helmet", () => {
             });
 
             it("updates with multiple additions and removals - overwrite and new", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            lang: "en",
-                            amp: undefined
-                        }}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            htmlAttributes={{
+                                lang: "en",
+                                amp: undefined
+                            }}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
                     ReactDOM.render(
-                        <Helmet
-                            htmlAttributes={{
-                                lang: "ja",
-                                id: "html-tag",
-                                title: "html tag"
-                            }}
-                        />,
+                        <HelmetProvider store={store}>
+                            <Helmet
+                                htmlAttributes={{
+                                    lang: "ja",
+                                    id: "html-tag",
+                                    title: "html tag"
+                                }}
+                            />
+                        </HelmetProvider>,
                         container
                     );
 
@@ -513,24 +591,29 @@ describe("Helmet", () => {
             });
 
             it("updates with multiple additions and removals - all new", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        htmlAttributes={{
-                            lang: "en",
-                            amp: undefined
-                        }}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            htmlAttributes={{
+                                lang: "en",
+                                amp: undefined
+                            }}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
                     ReactDOM.render(
-                        <Helmet
-                            htmlAttributes={{
-                                id: "html-tag",
-                                title: "html tag"
-                            }}
-                        />,
+                        <HelmetProvider store={store}>
+                            <Helmet
+                                htmlAttributes={{
+                                    id: "html-tag",
+                                    title: "html tag"
+                                }}
+                            />
+                        </HelmetProvider>,
                         container
                     );
 
@@ -560,7 +643,13 @@ describe("Helmet", () => {
                 });
 
                 it("attributes are not cleared", done => {
-                    ReactDOM.render(<Helmet />, container);
+                    const store = createHelmetStore();
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const htmlTag = document.getElementsByTagName(
@@ -576,12 +665,15 @@ describe("Helmet", () => {
                 });
 
                 it("attributes are overwritten if specified in helmet", done => {
+                    const store = createHelmetStore();
                     ReactDOM.render(
-                        <Helmet
-                            htmlAttributes={{
-                                test: "helmet-attr"
-                            }}
-                        />,
+                        <HelmetProvider store={store}>
+                            <Helmet
+                                htmlAttributes={{
+                                    test: "helmet-attr"
+                                }}
+                            />
+                        </HelmetProvider>,
                         container
                     );
 
@@ -601,17 +693,25 @@ describe("Helmet", () => {
                 });
 
                 it("attributes are cleared once managed in helmet", done => {
+                    const store = createHelmetStore();
                     ReactDOM.render(
-                        <Helmet
-                            htmlAttributes={{
-                                test: "helmet-attr"
-                            }}
-                        />,
+                        <HelmetProvider store={store}>
+                            <Helmet
+                                htmlAttributes={{
+                                    test: "helmet-attr"
+                                }}
+                            />
+                        </HelmetProvider>,
                         container
                     );
 
                     requestAnimationFrame(() => {
-                        ReactDOM.render(<Helmet />, container);
+                        ReactDOM.render(
+                            <HelmetProvider store={store}>
+                                <Helmet />
+                            </HelmetProvider>,
+                            container
+                        );
 
                         requestAnimationFrame(() => {
                             const htmlTag = document.getElementsByTagName(
@@ -631,28 +731,31 @@ describe("Helmet", () => {
 
         describe("onChangeClientState", () => {
             it("when handling client state change, calls the function with new state, addedTags and removedTags ", done => {
+                const store = createHelmetStore();
                 const spy = sinon.spy();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            base={{href: "http://mysite.com/"}}
-                            link={[
-                                {
-                                    href: "http://localhost/helmet",
-                                    rel: "canonical"
-                                }
-                            ]}
-                            meta={[{charset: "utf-8"}]}
-                            script={[
-                                {
-                                    src: "http://localhost/test.js",
-                                    type: "text/javascript"
-                                }
-                            ]}
-                            title={"Main Title"}
-                            onChangeClientState={spy}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                base={{href: "http://mysite.com/"}}
+                                link={[
+                                    {
+                                        href: "http://localhost/helmet",
+                                        rel: "canonical"
+                                    }
+                                ]}
+                                meta={[{charset: "utf-8"}]}
+                                script={[
+                                    {
+                                        src: "http://localhost/test.js",
+                                        type: "text/javascript"
+                                    }
+                                ]}
+                                title={"Main Title"}
+                                onChangeClientState={spy}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -707,15 +810,18 @@ describe("Helmet", () => {
             });
 
             it("calls the deepest defined callback with the deepest state", done => {
+                const store = createHelmetStore();
                 const spy = sinon.spy();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            title={"Main Title"}
-                            onChangeClientState={spy}
-                        />
-                        <Helmet title={"Deeper Title"} />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                title={"Main Title"}
+                                onChangeClientState={spy}
+                            />
+                            <Helmet title={"Deeper Title"} />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -732,8 +838,11 @@ describe("Helmet", () => {
 
         describe("base tag", () => {
             it("updates base tag", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet base={{href: "http://mysite.com/"}} />,
+                    <HelmetProvider store={store}>
+                        <Helmet base={{href: "http://mysite.com/"}} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -760,13 +869,21 @@ describe("Helmet", () => {
             });
 
             it("clears the base tag if one is not specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet base={{href: "http://mysite.com/"}} />,
+                    <HelmetProvider store={store}>
+                        <Helmet base={{href: "http://mysite.com/"}} />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -782,8 +899,11 @@ describe("Helmet", () => {
             });
 
             it("tags without 'href' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet base={{property: "won't work"}} />,
+                    <HelmetProvider store={store}>
+                        <Helmet base={{property: "won't work"}} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -800,11 +920,14 @@ describe("Helmet", () => {
             });
 
             it("sets base tag based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet base={{href: "http://mysite.com/"}} />
-                        <Helmet base={{href: "http://mysite.com/public"}} />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet base={{href: "http://mysite.com/"}} />
+                            <Helmet base={{href: "http://mysite.com/public"}} />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -836,7 +959,13 @@ describe("Helmet", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
-                ReactDOM.render(<Helmet base={{href: undefined}} />, container);
+                const store = createHelmetStore();
+                ReactDOM.render(
+                    <HelmetProvider store={store}>
+                        <Helmet base={{href: undefined}} />
+                    </HelmetProvider>,
+                    container
+                );
 
                 requestAnimationFrame(() => {
                     const tagNodes = headElement.querySelectorAll(
@@ -852,22 +981,28 @@ describe("Helmet", () => {
 
         describe("meta tags", () => {
             it("updates meta tags", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        meta={[
-                            {charset: "utf-8"},
-                            {
-                                name: "description",
-                                content: "Test description"
-                            },
-                            {
-                                "http-equiv": "content-type",
-                                content: "text/html"
-                            },
-                            {property: "og:type", content: "article"},
-                            {itemprop: "name", content: "Test name itemprop"}
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            meta={[
+                                {charset: "utf-8"},
+                                {
+                                    name: "description",
+                                    content: "Test description"
+                                },
+                                {
+                                    "http-equiv": "content-type",
+                                    content: "text/html"
+                                },
+                                {property: "og:type", content: "article"},
+                                {
+                                    itemprop: "name",
+                                    content: "Test name itemprop"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -904,17 +1039,28 @@ describe("Helmet", () => {
             });
 
             it("clears all meta tags if none are specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        meta={[
-                            {name: "description", content: "Test description"}
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            meta={[
+                                {
+                                    name: "description",
+                                    content: "Test description"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -930,8 +1076,11 @@ describe("Helmet", () => {
             });
 
             it("tags without 'name', 'http-equiv', 'property', 'charset', or 'itemprop' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet meta={[{href: "won't work"}]} />,
+                    <HelmetProvider store={store}>
+                        <Helmet meta={[{href: "won't work"}]} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -948,27 +1097,33 @@ describe("Helmet", () => {
             });
 
             it("sets meta tags based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            meta={[
-                                {charset: "utf-8"},
-                                {
-                                    name: "description",
-                                    content: "Test description"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            meta={[
-                                {
-                                    name: "description",
-                                    content: "Inner description"
-                                },
-                                {name: "keywords", content: "test,meta,tags"}
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                meta={[
+                                    {charset: "utf-8"},
+                                    {
+                                        name: "description",
+                                        content: "Test description"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                meta={[
+                                    {
+                                        name: "description",
+                                        content: "Inner description"
+                                    },
+                                    {
+                                        name: "keywords",
+                                        content: "test,meta,tags"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1026,19 +1181,22 @@ describe("Helmet", () => {
             });
 
             it("allows duplicate meta tags if specified in the same component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        meta={[
-                            {
-                                name: "description",
-                                content: "Test description"
-                            },
-                            {
-                                name: "description",
-                                content: "Duplicate description"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            meta={[
+                                {
+                                    name: "description",
+                                    content: "Test description"
+                                },
+                                {
+                                    name: "description",
+                                    content: "Duplicate description"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1087,29 +1245,32 @@ describe("Helmet", () => {
             });
 
             it("overrides duplicate meta tags with single meta tag in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            meta={[
-                                {
-                                    name: "description",
-                                    content: "Test description"
-                                },
-                                {
-                                    name: "description",
-                                    content: "Duplicate description"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            meta={[
-                                {
-                                    name: "description",
-                                    content: "Inner description"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                meta={[
+                                    {
+                                        name: "description",
+                                        content: "Test description"
+                                    },
+                                    {
+                                        name: "description",
+                                        content: "Duplicate description"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                meta={[
+                                    {
+                                        name: "description",
+                                        content: "Inner description"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1143,29 +1304,32 @@ describe("Helmet", () => {
             });
 
             it("overrides single meta tag with duplicate meta tags in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            meta={[
-                                {
-                                    name: "description",
-                                    content: "Test description"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            meta={[
-                                {
-                                    name: "description",
-                                    content: "Inner description"
-                                },
-                                {
-                                    name: "description",
-                                    content: "Inner duplicate description"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                meta={[
+                                    {
+                                        name: "description",
+                                        content: "Test description"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                meta={[
+                                    {
+                                        name: "description",
+                                        content: "Inner description"
+                                    },
+                                    {
+                                        name: "description",
+                                        content: "Inner duplicate description"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1214,15 +1378,18 @@ describe("Helmet", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        meta={[
-                            {
-                                name: undefined,
-                                content: "Inner duplicate description"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            meta={[
+                                {
+                                    name: undefined,
+                                    content: "Inner duplicate description"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1238,11 +1405,14 @@ describe("Helmet", () => {
             });
 
             it("fails gracefully when meta is wrong shape", done => {
+                const store = createHelmetStore();
                 const error = sinon.stub(console, "error");
                 const warn = sinon.stub(console, "warn");
 
                 ReactDOM.render(
-                    <Helmet meta={{name: "title", content: "some title"}} />,
+                    <HelmetProvider store={store}>
+                        <Helmet meta={{name: "title", content: "some title"}} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1271,20 +1441,23 @@ describe("Helmet", () => {
 
         describe("link tags", () => {
             it("updates link tags", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {
-                                href: "http://localhost/helmet",
-                                rel: "canonical"
-                            },
-                            {
-                                href: "http://localhost/style.css",
-                                rel: "stylesheet",
-                                type: "text/css"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            link={[
+                                {
+                                    href: "http://localhost/helmet",
+                                    rel: "canonical"
+                                },
+                                {
+                                    href: "http://localhost/style.css",
+                                    rel: "stylesheet",
+                                    type: "text/css"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1317,20 +1490,28 @@ describe("Helmet", () => {
             });
 
             it("clears all link tags if none are specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {
-                                href: "http://localhost/helmet",
-                                rel: "canonical"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            link={[
+                                {
+                                    href: "http://localhost/helmet",
+                                    rel: "canonical"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const tagNodes = headElement.querySelectorAll(
@@ -1349,8 +1530,11 @@ describe("Helmet", () => {
             });
 
             it("tags without 'href' or 'rel' are not accepted, even if they are valid for other tags", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet link={[{"http-equiv": "won't work"}]} />,
+                    <HelmetProvider store={store}>
+                        <Helmet link={[{"http-equiv": "won't work"}]} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1368,33 +1552,36 @@ describe("Helmet", () => {
             });
 
             it("tags 'rel' and 'href' properly use 'rel' as the primary identification for this tag, regardless of ordering", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            link={[
-                                {
-                                    href: "http://localhost/helmet",
-                                    rel: "canonical"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "canonical",
-                                    href: "http://localhost/helmet/new"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {
-                                    href: "http://localhost/helmet/newest",
-                                    rel: "canonical"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                link={[
+                                    {
+                                        href: "http://localhost/helmet",
+                                        rel: "canonical"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "canonical",
+                                        href: "http://localhost/helmet/new"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                link={[
+                                    {
+                                        href: "http://localhost/helmet/newest",
+                                        rel: "canonical"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1426,29 +1613,32 @@ describe("Helmet", () => {
             });
 
             it("tags with rel='stylesheet' uses the href as the primary identification of the tag, regardless of ordering", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            link={[
-                                {
-                                    href: "http://localhost/style.css",
-                                    rel: "stylesheet",
-                                    type: "text/css",
-                                    media: "all"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "stylesheet",
-                                    href: "http://localhost/inner.css",
-                                    type: "text/css",
-                                    media: "all"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                link={[
+                                    {
+                                        href: "http://localhost/style.css",
+                                        rel: "stylesheet",
+                                        type: "text/css",
+                                        media: "all"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "stylesheet",
+                                        href: "http://localhost/inner.css",
+                                        type: "text/css",
+                                        media: "all"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1499,38 +1689,41 @@ describe("Helmet", () => {
             });
 
             it("sets link tags based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "canonical",
-                                    href: "http://localhost/helmet"
-                                },
-                                {
-                                    href: "http://localhost/style.css",
-                                    rel: "stylesheet",
-                                    type: "text/css",
-                                    media: "all"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "canonical",
-                                    href:
-                                        "http://localhost/helmet/innercomponent"
-                                },
-                                {
-                                    href: "http://localhost/inner.css",
-                                    rel: "stylesheet",
-                                    type: "text/css",
-                                    media: "all"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "canonical",
+                                        href: "http://localhost/helmet"
+                                    },
+                                    {
+                                        href: "http://localhost/style.css",
+                                        rel: "stylesheet",
+                                        type: "text/css",
+                                        media: "all"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "canonical",
+                                        href:
+                                            "http://localhost/helmet/innercomponent"
+                                    },
+                                    {
+                                        href: "http://localhost/inner.css",
+                                        rel: "stylesheet",
+                                        type: "text/css",
+                                        media: "all"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1592,19 +1785,22 @@ describe("Helmet", () => {
             });
 
             it("allows duplicate link tags if specified in the same component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {
-                                rel: "canonical",
-                                href: "http://localhost/helmet"
-                            },
-                            {
-                                rel: "canonical",
-                                href: "http://localhost/helmet/component"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            link={[
+                                {
+                                    rel: "canonical",
+                                    href: "http://localhost/helmet"
+                                },
+                                {
+                                    rel: "canonical",
+                                    href: "http://localhost/helmet/component"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1649,30 +1845,34 @@ describe("Helmet", () => {
             });
 
             it("overrides duplicate link tags with a single link tag in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "canonical",
-                                    href: "http://localhost/helmet"
-                                },
-                                {
-                                    rel: "canonical",
-                                    href: "http://localhost/helmet/component"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "canonical",
-                                    href:
-                                        "http://localhost/helmet/innercomponent"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "canonical",
+                                        href: "http://localhost/helmet"
+                                    },
+                                    {
+                                        rel: "canonical",
+                                        href:
+                                            "http://localhost/helmet/component"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "canonical",
+                                        href:
+                                            "http://localhost/helmet/innercomponent"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1704,30 +1904,34 @@ describe("Helmet", () => {
             });
 
             it("overrides single link tag with duplicate link tags in a nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "canonical",
-                                    href: "http://localhost/helmet"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            link={[
-                                {
-                                    rel: "canonical",
-                                    href: "http://localhost/helmet/component"
-                                },
-                                {
-                                    rel: "canonical",
-                                    href:
-                                        "http://localhost/helmet/innercomponent"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "canonical",
+                                        href: "http://localhost/helmet"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                link={[
+                                    {
+                                        rel: "canonical",
+                                        href:
+                                            "http://localhost/helmet/component"
+                                    },
+                                    {
+                                        rel: "canonical",
+                                        href:
+                                            "http://localhost/helmet/innercomponent"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1772,16 +1976,19 @@ describe("Helmet", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {rel: "icon", sizes: "192x192", href: null},
-                            {
-                                rel: "canonical",
-                                href: "http://localhost/helmet/component"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            link={[
+                                {rel: "icon", sizes: "192x192", href: null},
+                                {
+                                    rel: "canonical",
+                                    href: "http://localhost/helmet/component"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1814,6 +2021,7 @@ describe("Helmet", () => {
 
         describe("script tags", () => {
             it("updates script tags", done => {
+                const store = createHelmetStore();
                 const scriptInnerHTML = `
                   {
                     "@context": "http://schema.org",
@@ -1822,22 +2030,24 @@ describe("Helmet", () => {
                   }
                 `;
                 ReactDOM.render(
-                    <Helmet
-                        script={[
-                            {
-                                src: "http://localhost/test.js",
-                                type: "text/javascript"
-                            },
-                            {
-                                src: "http://localhost/test2.js",
-                                type: "text/javascript"
-                            },
-                            {
-                                type: "application/ld+json",
-                                innerHTML: scriptInnerHTML
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            script={[
+                                {
+                                    src: "http://localhost/test.js",
+                                    type: "text/javascript"
+                                },
+                                {
+                                    src: "http://localhost/test2.js",
+                                    type: "text/javascript"
+                                },
+                                {
+                                    type: "application/ld+json",
+                                    innerHTML: scriptInnerHTML
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1873,20 +2083,28 @@ describe("Helmet", () => {
             });
 
             it("clears all scripts tags if none are specified", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        script={[
-                            {
-                                src: "http://localhost/test.js",
-                                type: "text/javascript"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            script={[
+                                {
+                                    src: "http://localhost/test.js",
+                                    type: "text/javascript"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -1902,8 +2120,11 @@ describe("Helmet", () => {
             });
 
             it("tags without 'src' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet script={[{property: "won't work"}]} />,
+                    <HelmetProvider store={store}>
+                        <Helmet script={[{property: "won't work"}]} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1920,25 +2141,28 @@ describe("Helmet", () => {
             });
 
             it("sets script tags based on deepest nested component", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <div>
-                        <Helmet
-                            script={[
-                                {
-                                    src: "http://localhost/test.js",
-                                    type: "text/javascript"
-                                }
-                            ]}
-                        />
-                        <Helmet
-                            script={[
-                                {
-                                    src: "http://localhost/test2.js",
-                                    type: "text/javascript"
-                                }
-                            ]}
-                        />
-                    </div>,
+                    <HelmetProvider store={store}>
+                        <div>
+                            <Helmet
+                                script={[
+                                    {
+                                        src: "http://localhost/test.js",
+                                        type: "text/javascript"
+                                    }
+                                ]}
+                            />
+                            <Helmet
+                                script={[
+                                    {
+                                        src: "http://localhost/test2.js",
+                                        type: "text/javascript"
+                                    }
+                                ]}
+                            />
+                        </div>
+                    </HelmetProvider>,
                     container
                 );
 
@@ -1987,15 +2211,18 @@ describe("Helmet", () => {
             });
 
             it("sets undefined attribute values to empty strings", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        script={[
-                            {
-                                src: "foo.js",
-                                async: undefined
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            script={[
+                                {
+                                    src: "foo.js",
+                                    async: undefined
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2016,15 +2243,18 @@ describe("Helmet", () => {
             });
 
             it("does not render tag when primary attribute (src) is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        script={[
-                            {
-                                src: undefined,
-                                type: "text/javascript"
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            script={[
+                                {
+                                    src: undefined,
+                                    type: "text/javascript"
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2040,14 +2270,17 @@ describe("Helmet", () => {
             });
 
             it("does not render tag when primary attribute (innerHTML) is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        script={[
-                            {
-                                innerHTML: undefined
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            script={[
+                                {
+                                    innerHTML: undefined
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2065,11 +2298,16 @@ describe("Helmet", () => {
 
         describe("noscript tags", () => {
             it("updates noscript tags", done => {
+                const store = createHelmetStore();
                 const noscriptInnerHTML = `<link rel="stylesheet" type="text/css" href="foo.css" />`;
                 ReactDOM.render(
-                    <Helmet
-                        noscript={[{id: "bar", innerHTML: noscriptInnerHTML}]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            noscript={[
+                                {id: "bar", innerHTML: noscriptInnerHTML}
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2090,10 +2328,21 @@ describe("Helmet", () => {
             });
 
             it("clears all noscripts tags if none are specified", done => {
-                ReactDOM.render(<Helmet noscript={[{id: "bar"}]} />, container);
+                const store = createHelmetStore();
+                ReactDOM.render(
+                    <HelmetProvider store={store}>
+                        <Helmet noscript={[{id: "bar"}]} />
+                    </HelmetProvider>,
+                    container
+                );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -2109,8 +2358,11 @@ describe("Helmet", () => {
             });
 
             it("tags without 'innerHTML' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet noscript={[{property: "won't work"}]} />,
+                    <HelmetProvider store={store}>
+                        <Helmet noscript={[{property: "won't work"}]} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2127,14 +2379,17 @@ describe("Helmet", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        noscript={[
-                            {
-                                innerHTML: undefined
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            noscript={[
+                                {
+                                    innerHTML: undefined
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2152,6 +2407,7 @@ describe("Helmet", () => {
 
         describe("style tags", () => {
             it("updates style tags", done => {
+                const store = createHelmetStore();
                 const cssText1 = `
                     body {
                         background-color: green;
@@ -2163,17 +2419,19 @@ describe("Helmet", () => {
                     }
                 `;
                 ReactDOM.render(
-                    <Helmet
-                        style={[
-                            {
-                                type: "text/css",
-                                cssText: cssText1
-                            },
-                            {
-                                cssText: cssText2
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            style={[
+                                {
+                                    type: "text/css",
+                                    cssText: cssText1
+                                },
+                                {
+                                    cssText: cssText2
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2210,25 +2468,33 @@ describe("Helmet", () => {
             });
 
             it("clears all style tags if none are specified", done => {
+                const store = createHelmetStore();
                 const cssText = `
                     body {
                         background-color: green;
                     }
                 `;
                 ReactDOM.render(
-                    <Helmet
-                        style={[
-                            {
-                                type: "text/css",
-                                cssText
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            style={[
+                                {
+                                    type: "text/css",
+                                    cssText
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
                 requestAnimationFrame(() => {
-                    ReactDOM.render(<Helmet />, container);
+                    ReactDOM.render(
+                        <HelmetProvider store={store}>
+                            <Helmet />
+                        </HelmetProvider>,
+                        container
+                    );
 
                     requestAnimationFrame(() => {
                         const existingTags = headElement.querySelectorAll(
@@ -2244,8 +2510,11 @@ describe("Helmet", () => {
             });
 
             it("tags without 'cssText' are not accepted", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet style={[{property: "won't work"}]} />,
+                    <HelmetProvider store={store}>
+                        <Helmet style={[{property: "won't work"}]} />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2262,14 +2531,17 @@ describe("Helmet", () => {
             });
 
             it("does not render tag when primary attribute is null", done => {
+                const store = createHelmetStore();
                 ReactDOM.render(
-                    <Helmet
-                        style={[
-                            {
-                                cssText: undefined
-                            }
-                        ]}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            style={[
+                                {
+                                    cssText: undefined
+                                }
+                            ]}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -2296,24 +2568,27 @@ describe("Helmet", () => {
         });
 
         it("executes synchronously when defer={true} and async otherwise", done => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <div>
-                    <Helmet
-                        defer={false}
-                        script={[
-                            {
-                                innerHTML: `window.__spy__(1)`
-                            }
-                        ]}
-                    />
-                    <Helmet
-                        script={[
-                            {
-                                innerHTML: `window.__spy__(2)`
-                            }
-                        ]}
-                    />
-                </div>,
+                <HelmetProvider store={store}>
+                    <div>
+                        <Helmet
+                            defer={false}
+                            script={[
+                                {
+                                    innerHTML: `window.__spy__(1)`
+                                }
+                            ]}
+                        />
+                        <Helmet
+                            script={[
+                                {
+                                    innerHTML: `window.__spy__(2)`
+                                }
+                            ]}
+                        />
+                    </div>
+                </HelmetProvider>,
                 container
             );
 
@@ -2367,8 +2642,9 @@ describe("Helmet", () => {
         });
 
         it("provides initial values if no state is found", () => {
-            let head = Helmet.rewind();
-            head = Helmet.rewind();
+            const store = createHelmetStore();
+            let head = store.renderStatic();
+            head = store.renderStatic();
 
             expect(head.meta).to.exist;
             expect(head.meta).to.respondTo("toString");
@@ -2377,12 +2653,15 @@ describe("Helmet", () => {
         });
 
         it("encodes special characters in title", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet title="Dangerous <script> include" />,
+                <HelmetProvider store={store}>
+                    <Helmet title="Dangerous <script> include" />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2391,15 +2670,18 @@ describe("Helmet", () => {
         });
 
         it("opts out of string encoding", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    encodeSpecialCharacters={false}
-                    title={"This is text and & and '."}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        encodeSpecialCharacters={false}
+                        title={"This is text and & and '."}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
 
@@ -2407,12 +2689,15 @@ describe("Helmet", () => {
         });
 
         it("renders title as React component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet title={"Dangerous <script> include"} />,
+                <HelmetProvider store={store}>
+                    <Helmet title={"Dangerous <script> include"} />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toComponent");
@@ -2428,9 +2713,7 @@ describe("Helmet", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {titleComponent}
-                </div>
+                <div>{titleComponent}</div>
             );
 
             expect(markup).to.be
@@ -2439,15 +2722,18 @@ describe("Helmet", () => {
         });
 
         it("renders title with itemprop name as React component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    title={"Title with Itemprop"}
-                    titleAttributes={{itemprop: "name"}}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        title={"Title with Itemprop"}
+                        titleAttributes={{itemprop: "name"}}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toComponent");
@@ -2463,9 +2749,7 @@ describe("Helmet", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {titleComponent}
-                </div>
+                <div>{titleComponent}</div>
             );
 
             expect(markup).to.be
@@ -2474,12 +2758,17 @@ describe("Helmet", () => {
         });
 
         it("renders base tag as React component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet base={{target: "_blank", href: "http://localhost/"}} />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        base={{target: "_blank", href: "http://localhost/"}}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.base).to.exist;
             expect(head.base).to.respondTo("toComponent");
@@ -2495,9 +2784,7 @@ describe("Helmet", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {baseComponent}
-                </div>
+                <div>{baseComponent}</div>
             );
 
             expect(markup).to.be
@@ -2506,24 +2793,30 @@ describe("Helmet", () => {
         });
 
         it("renders meta tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    meta={[
-                        {charset: "utf-8"},
-                        {
-                            name: "description",
-                            content:
-                                "Test description & encoding of special characters like ' \" > < `"
-                        },
-                        {"http-equiv": "content-type", content: "text/html"},
-                        {property: "og:type", content: "article"},
-                        {itemprop: "name", content: "Test name itemprop"}
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        meta={[
+                            {charset: "utf-8"},
+                            {
+                                name: "description",
+                                content:
+                                    "Test description & encoding of special characters like ' \" > < `"
+                            },
+                            {
+                                "http-equiv": "content-type",
+                                content: "text/html"
+                            },
+                            {property: "og:type", content: "article"},
+                            {itemprop: "name", content: "Test name itemprop"}
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.meta).to.exist;
             expect(head.meta).to.respondTo("toComponent");
@@ -2539,9 +2832,7 @@ describe("Helmet", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {metaComponent}
-                </div>
+                <div>{metaComponent}</div>
             );
 
             expect(markup).to.be
@@ -2550,21 +2841,24 @@ describe("Helmet", () => {
         });
 
         it("renders link tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    link={[
-                        {href: "http://localhost/helmet", rel: "canonical"},
-                        {
-                            href: "http://localhost/style.css",
-                            rel: "stylesheet",
-                            type: "text/css"
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        link={[
+                            {href: "http://localhost/helmet", rel: "canonical"},
+                            {
+                                href: "http://localhost/style.css",
+                                rel: "stylesheet",
+                                type: "text/css"
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.link).to.exist;
             expect(head.link).to.respondTo("toComponent");
@@ -2580,9 +2874,7 @@ describe("Helmet", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {linkComponent}
-                </div>
+                <div>{linkComponent}</div>
             );
 
             expect(markup).to.be
@@ -2591,23 +2883,26 @@ describe("Helmet", () => {
         });
 
         it("renders script tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    script={[
-                        {
-                            src: "http://localhost/test.js",
-                            type: "text/javascript"
-                        },
-                        {
-                            src: "http://localhost/test2.js",
-                            type: "text/javascript"
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        script={[
+                            {
+                                src: "http://localhost/test.js",
+                                type: "text/javascript"
+                            },
+                            {
+                                src: "http://localhost/test2.js",
+                                type: "text/javascript"
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.script).to.exist;
             expect(head.script).to.respondTo("toComponent");
@@ -2623,9 +2918,7 @@ describe("Helmet", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {scriptComponent}
-                </div>
+                <div>{scriptComponent}</div>
             );
 
             expect(markup).to.be
@@ -2634,25 +2927,28 @@ describe("Helmet", () => {
         });
 
         it("renders noscript tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    noscript={[
-                        {
-                            id: "foo",
-                            innerHTML:
-                                '<link rel="stylesheet" type="text/css" href="/style.css" />'
-                        },
-                        {
-                            id: "bar",
-                            innerHTML:
-                                '<link rel="stylesheet" type="text/css" href="/style2.css" />'
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        noscript={[
+                            {
+                                id: "foo",
+                                innerHTML:
+                                    '<link rel="stylesheet" type="text/css" href="/style.css" />'
+                            },
+                            {
+                                id: "bar",
+                                innerHTML:
+                                    '<link rel="stylesheet" type="text/css" href="/style2.css" />'
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.noscript).to.exist;
             expect(head.noscript).to.respondTo("toComponent");
@@ -2668,9 +2964,7 @@ describe("Helmet", () => {
             });
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {noscriptComponent}
-                </div>
+                <div>{noscriptComponent}</div>
             );
 
             expect(markup).to.be
@@ -2679,23 +2973,26 @@ describe("Helmet", () => {
         });
 
         it("renders style tags as React components", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    style={[
-                        {
-                            type: "text/css",
-                            cssText: `body {background-color: green;}`
-                        },
-                        {
-                            type: "text/css",
-                            cssText: `p {font-size: 12px;}`
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        style={[
+                            {
+                                type: "text/css",
+                                cssText: `body {background-color: green;}`
+                            },
+                            {
+                                type: "text/css",
+                                cssText: `p {font-size: 12px;}`
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.style).to.exist;
             expect(head.style).to.respondTo("toComponent");
@@ -2705,9 +3002,7 @@ describe("Helmet", () => {
             expect(styleComponent).to.be.an("array").that.has.length.of(2);
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {styleComponent}
-                </div>
+                <div>{styleComponent}</div>
             );
 
             expect(markup).to.be
@@ -2716,12 +3011,15 @@ describe("Helmet", () => {
         });
 
         it("renders title tag as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet title={"Dangerous <script> include"} />,
+                <HelmetProvider store={store}>
+                    <Helmet title={"Dangerous <script> include"} />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2732,15 +3030,18 @@ describe("Helmet", () => {
         });
 
         it("renders title with itemprop name as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    title={"Title with Itemprop"}
-                    titleAttributes={{itemprop: "name"}}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        title={"Title with Itemprop"}
+                        titleAttributes={{itemprop: "name"}}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2752,12 +3053,17 @@ describe("Helmet", () => {
         });
 
         it("renders base tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet base={{target: "_blank", href: "http://localhost/"}} />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        base={{target: "_blank", href: "http://localhost/"}}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.base).to.exist;
             expect(head.base).to.respondTo("toString");
@@ -2768,24 +3074,30 @@ describe("Helmet", () => {
         });
 
         it("renders meta tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    meta={[
-                        {charset: "utf-8"},
-                        {
-                            name: "description",
-                            content:
-                                "Test description & encoding of special characters like ' \" > < `"
-                        },
-                        {"http-equiv": "content-type", content: "text/html"},
-                        {property: "og:type", content: "article"},
-                        {itemprop: "name", content: "Test name itemprop"}
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        meta={[
+                            {charset: "utf-8"},
+                            {
+                                name: "description",
+                                content:
+                                    "Test description & encoding of special characters like ' \" > < `"
+                            },
+                            {
+                                "http-equiv": "content-type",
+                                content: "text/html"
+                            },
+                            {property: "og:type", content: "article"},
+                            {itemprop: "name", content: "Test name itemprop"}
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.meta).to.exist;
             expect(head.meta).to.respondTo("toString");
@@ -2796,21 +3108,24 @@ describe("Helmet", () => {
         });
 
         it("renders link tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    link={[
-                        {href: "http://localhost/helmet", rel: "canonical"},
-                        {
-                            href: "http://localhost/style.css",
-                            rel: "stylesheet",
-                            type: "text/css"
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        link={[
+                            {href: "http://localhost/helmet", rel: "canonical"},
+                            {
+                                href: "http://localhost/style.css",
+                                rel: "stylesheet",
+                                type: "text/css"
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.link).to.exist;
             expect(head.link).to.respondTo("toString");
@@ -2821,23 +3136,26 @@ describe("Helmet", () => {
         });
 
         it("renders script tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    script={[
-                        {
-                            src: "http://localhost/test.js",
-                            type: "text/javascript"
-                        },
-                        {
-                            src: "http://localhost/test2.js",
-                            type: "text/javascript"
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        script={[
+                            {
+                                src: "http://localhost/test.js",
+                                type: "text/javascript"
+                            },
+                            {
+                                src: "http://localhost/test2.js",
+                                type: "text/javascript"
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.script).to.exist;
             expect(head.script).to.respondTo("toString");
@@ -2848,23 +3166,26 @@ describe("Helmet", () => {
         });
 
         it("renders style tags as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    style={[
-                        {
-                            type: "text/css",
-                            cssText: `body {background-color: green;}`
-                        },
-                        {
-                            type: "text/css",
-                            cssText: `p {font-size: 12px;}`
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        style={[
+                            {
+                                type: "text/css",
+                                cssText: `body {background-color: green;}`
+                            },
+                            {
+                                type: "text/css",
+                                cssText: `p {font-size: 12px;}`
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.style).to.exist;
             expect(head.style).to.respondTo("toString");
@@ -2875,17 +3196,20 @@ describe("Helmet", () => {
         });
 
         it("renders html attributes as component", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    htmlAttributes={{
-                        lang: "ga",
-                        className: "myClassName"
-                    }}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        htmlAttributes={{
+                            lang: "ga",
+                            className: "myClassName"
+                        }}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const {htmlAttributes} = Helmet.rewind();
+            const {htmlAttributes} = store.renderStatic();
             const attrs = htmlAttributes.toComponent();
 
             expect(attrs).to.exist;
@@ -2900,17 +3224,20 @@ describe("Helmet", () => {
         });
 
         it("renders html attributes as string", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    htmlAttributes={{
-                        lang: "ga",
-                        class: "myClassName"
-                    }}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        htmlAttributes={{
+                            lang: "ga",
+                            class: "myClassName"
+                        }}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.htmlAttributes).to.exist;
             expect(head.htmlAttributes).to.respondTo("toString");
@@ -2924,14 +3251,17 @@ describe("Helmet", () => {
             const chineseTitle = "膣膗 鍆錌雔";
             const stringifiedChineseTitle = `<title ${HELMET_ATTRIBUTE}="true">${chineseTitle}</title>`;
 
+            const store = createHelmetStore();
             ReactDOM.render(
-                <div>
-                    <Helmet title={chineseTitle} />
-                </div>,
+                <HelmetProvider store={store}>
+                    <div>
+                        <Helmet title={chineseTitle} />
+                    </div>
+                </HelmetProvider>,
                 container
             );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.title).to.exist;
             expect(head.title).to.respondTo("toString");
@@ -2942,9 +3272,15 @@ describe("Helmet", () => {
         });
 
         it("rewind() provides a fallback object for empty Helmet state", () => {
-            ReactDOM.render(<div />, container);
+            const store = createHelmetStore();
+            ReactDOM.render(
+                <HelmetProvider store={store}>
+                    <div />
+                </HelmetProvider>,
+                container
+            );
 
-            const head = Helmet.rewind();
+            const head = store.renderStatic();
 
             expect(head.htmlAttributes).to.exist;
             expect(head.htmlAttributes).to.respondTo("toString");
@@ -2961,9 +3297,7 @@ describe("Helmet", () => {
             expect(head.title).to.respondTo("toComponent");
 
             const markup = ReactServer.renderToStaticMarkup(
-                <div>
-                    {head.title.toComponent()}
-                </div>
+                <div>{head.title.toComponent()}</div>
             );
 
             expect(markup).to.be
@@ -3010,19 +3344,22 @@ describe("Helmet", () => {
         });
 
         it("does not render undefined attribute values", () => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    script={[
-                        {
-                            src: "foo.js",
-                            async: undefined
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        script={[
+                            {
+                                src: "foo.js",
+                                async: undefined
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
-            const {script} = Helmet.rewind();
+            const {script} = store.renderStatic();
             const stringifiedScriptTag = script.toString();
 
             expect(stringifiedScriptTag).to.be
@@ -3037,21 +3374,19 @@ describe("Helmet", () => {
     });
 
     describe("misc", () => {
-        it("throws in rewind() when a DOM is present", () => {
-            ReactDOM.render(<Helmet title={"Fancy title"} />, container);
-
-            expect(Helmet.rewind).to.throw(
-                "You may only call rewind() on the server. Call peek() to read the current state."
-            );
-        });
-
         it("lets you read current state in peek() whether or not a DOM is present", done => {
-            ReactDOM.render(<Helmet title={"Fancy title"} />, container);
+            const store = createHelmetStore();
+            ReactDOM.render(
+                <HelmetProvider store={store}>
+                    <Helmet title={"Fancy title"} />
+                </HelmetProvider>,
+                container
+            );
 
             requestAnimationFrame(() => {
-                expect(Helmet.peek().title).to.be.equal("Fancy title");
+                expect(store.peek().title).to.be.equal("Fancy title");
                 Helmet.canUseDOM = false;
-                expect(Helmet.peek().title).to.be.equal("Fancy title");
+                expect(store.peek().title).to.be.equal("Fancy title");
                 Helmet.canUseDOM = true;
 
                 done();
@@ -3059,15 +3394,18 @@ describe("Helmet", () => {
         });
 
         it("encodes special characters", done => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    meta={[
-                        {
-                            name: "description",
-                            content: 'This is "quoted" text and & and \'.'
-                        }
-                    ]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        meta={[
+                            {
+                                name: "description",
+                                content: 'This is "quoted" text and & and \'.'
+                            }
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 
@@ -3100,26 +3438,36 @@ describe("Helmet", () => {
         });
 
         it("does not change the DOM if it recevies identical props", done => {
+            const store = createHelmetStore();
             const spy = sinon.spy();
             ReactDOM.render(
-                <Helmet
-                    meta={[{name: "description", content: "Test description"}]}
-                    title={"Test Title"}
-                    onChangeClientState={spy}
-                />,
-                container
-            );
-
-            requestAnimationFrame(() => {
-                // Re-rendering will pass new props to an already mounted Helmet
-                ReactDOM.render(
+                <HelmetProvider store={store}>
                     <Helmet
                         meta={[
                             {name: "description", content: "Test description"}
                         ]}
                         title={"Test Title"}
                         onChangeClientState={spy}
-                    />,
+                    />
+                </HelmetProvider>,
+                container
+            );
+
+            requestAnimationFrame(() => {
+                // Re-rendering will pass new props to an already mounted Helmet
+                ReactDOM.render(
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            meta={[
+                                {
+                                    name: "description",
+                                    content: "Test description"
+                                }
+                            ]}
+                            title={"Test Title"}
+                            onChangeClientState={spy}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -3132,19 +3480,22 @@ describe("Helmet", () => {
         });
 
         it("does not write the DOM if the client and server are identical", done => {
+            const store = createHelmetStore();
             headElement.innerHTML = `<script ${HELMET_ATTRIBUTE}="true" src="http://localhost/test.js" type="text/javascript" />`;
 
             const spy = sinon.spy();
             ReactDOM.render(
-                <Helmet
-                    script={[
-                        {
-                            src: "http://localhost/test.js",
-                            type: "text/javascript"
-                        }
-                    ]}
-                    onChangeClientState={spy}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        script={[
+                            {
+                                src: "http://localhost/test.js",
+                                type: "text/javascript"
+                            }
+                        ]}
+                        onChangeClientState={spy}
+                    />
+                </HelmetProvider>,
                 container
             );
 
@@ -3161,21 +3512,26 @@ describe("Helmet", () => {
         });
 
         it("only adds new tags and preserves tags when rendering additional Helmet instances", done => {
+            const store = createHelmetStore();
             const spy = sinon.spy();
             let addedTags;
             let removedTags;
             ReactDOM.render(
-                <Helmet
-                    link={[
-                        {
-                            href: "http://localhost/style.css",
-                            rel: "stylesheet",
-                            type: "text/css"
-                        }
-                    ]}
-                    meta={[{name: "description", content: "Test description"}]}
-                    onChangeClientState={spy}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        link={[
+                            {
+                                href: "http://localhost/style.css",
+                                rel: "stylesheet",
+                                type: "text/css"
+                            }
+                        ]}
+                        meta={[
+                            {name: "description", content: "Test description"}
+                        ]}
+                        onChangeClientState={spy}
+                    />
+                </HelmetProvider>,
                 container
             );
 
@@ -3198,24 +3554,29 @@ describe("Helmet", () => {
 
                 // Re-rendering will pass new props to an already mounted Helmet
                 ReactDOM.render(
-                    <Helmet
-                        link={[
-                            {
-                                href: "http://localhost/style.css",
-                                rel: "stylesheet",
-                                type: "text/css"
-                            },
-                            {
-                                href: "http://localhost/style2.css",
-                                rel: "stylesheet",
-                                type: "text/css"
-                            }
-                        ]}
-                        meta={[
-                            {name: "description", content: "New description"}
-                        ]}
-                        onChangeClientState={spy}
-                    />,
+                    <HelmetProvider store={store}>
+                        <Helmet
+                            link={[
+                                {
+                                    href: "http://localhost/style.css",
+                                    rel: "stylesheet",
+                                    type: "text/css"
+                                },
+                                {
+                                    href: "http://localhost/style2.css",
+                                    rel: "stylesheet",
+                                    type: "text/css"
+                                }
+                            ]}
+                            meta={[
+                                {
+                                    name: "description",
+                                    content: "New description"
+                                }
+                            ]}
+                            onChangeClientState={spy}
+                        />
+                    </HelmetProvider>,
                     container
                 );
 
@@ -3247,12 +3608,15 @@ describe("Helmet", () => {
         });
 
         it("does not accept nested Helmets", done => {
+            const store = createHelmetStore();
             const warn = sinon.stub(console, "warn");
 
             ReactDOM.render(
-                <Helmet title={"Test Title"}>
-                    <Helmet title={"Title you'll never see"} />
-                </Helmet>,
+                <HelmetProvider store={store}>
+                    <Helmet title={"Test Title"}>
+                        <Helmet title={"Title you'll never see"} />
+                    </Helmet>
+                </HelmetProvider>,
                 container
             );
 
@@ -3271,10 +3635,15 @@ describe("Helmet", () => {
         });
 
         it("recognizes valid tags regardless of attribute ordering", done => {
+            const store = createHelmetStore();
             ReactDOM.render(
-                <Helmet
-                    meta={[{content: "Test Description", name: "description"}]}
-                />,
+                <HelmetProvider store={store}>
+                    <Helmet
+                        meta={[
+                            {content: "Test Description", name: "description"}
+                        ]}
+                    />
+                </HelmetProvider>,
                 container
             );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,6 +1478,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.2:
     create-hash "^1.1.0"
     inherits "^2.0.1"
 
+create-react-context@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
+
 cross-env@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-3.2.4.tgz#9e0585f277864ed421ce756f81a980ff0d698aba"
@@ -2103,9 +2107,9 @@ evp_bytestokey@^1.0.0:
   dependencies:
     create-hash "^1.1.1"
 
-exenv@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.1.tgz#75de1c8dee02e952b102aa17f8875973e0df14f9"
+exenv@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -2589,6 +2593,10 @@ hmac-drbg@^1.0.0:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3201,6 +3209,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.2.1:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.5.tgz#9fc6e737b1c4d151d8f9cae2247305d552ce748f"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -3248,7 +3260,7 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.keys@^3.0.0, lodash.keys@^3.1.2:
+lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
   dependencies:
@@ -3976,12 +3988,14 @@ react-dom@^15.x:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-react-side-effect@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.0.tgz#57209f7ebc940d55e0fda82fe51422654175d609"
+react-reffect@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-reffect/-/react-reffect-2.1.0.tgz#73e2ac164064f0021c3d84a725bf589dcc2ba7f4"
   dependencies:
-    exenv "^1.2.1"
-    shallowequal "^0.2.2"
+    create-react-context "^0.1.6"
+    exenv "^1.2.2"
+    hoist-non-react-statics "^2.5.0"
+    redux "^3.7.2"
 
 react@^15.x:
   version "15.4.2"
@@ -4067,6 +4081,15 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redux@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -4286,12 +4309,6 @@ sha.js@^2.3.6:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
-
-shallowequal@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
-  dependencies:
-    lodash.keys "^3.1.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -4546,6 +4563,10 @@ supports-color@3.1.2, supports-color@^3.1.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+symbol-observable@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 table@^3.7.8:
   version "3.8.3"


### PR DESCRIPTION
Helmet.rewind() causes a race condition problem when using React 16 renderToNodeStream(). Here is a discussion about it. 

https://github.com/nfl/react-helmet/issues/216
https://github.com/gaearon/react-side-effect/issues/23

This pull request use a thread-safe react-reffect instead of react-side-effect to support renderToStream().

[react-reffect](https://github.com/kouhin/react-reffect) is a fork of react-side-effect. It uses redux & new react context api to create new context per request. 

Here is an example: 

```jsx
new Promise((resolve, reject) => {
    const helmetStore = createHelmetStore();
    let body = '';
    ReactDOMServer.renderToNodeStream(
        <HelmetProvider store={helmetStore}>
          <App />
        </HelmetProvider>,
    )
      .on('data', (chunk) => {
        body += chunk;
      })
      .on('error', (err) => {
        reject(err);
      })
      .on('end', () => {
        resolve({
          body,
          helmet: helmetStore.renderStatic(),
        });
      });
}).then(({body, helmet}) => {
    // Create html with body and helmet object
});
```

#### Migrate from current react-helmet

Migration is easy. 

```jsx
import {Helmet} from "react-helmet";

<Parent>
    <Helmet>
        <title>My Title</title>
        <meta name="description" content="Helmet application" />
    </Helmet>

    <Child>
        <Helmet>
            <title>Nested Title</title>
            <meta name="description" content="Nested component" />
        </Helmet>
    </Child>
</Parent>
```

to 

```jsx
import {Helmet, HelmetProvider, createHelmetStore} from "react-helmet";

const store = createHelmetStore();
<HelmetProvider store={store}>
    <Parent>
        <Helmet>
            <title>My Title</title>
            <meta name="description" content="Helmet application" />
        </Helmet>

        <Child>
            <Helmet>
                <title>Nested Title</title>
                <meta name="description" content="Nested component" />
            </Helmet>
        </Child>
    </Parent>
</HelmetProvider>
```

And use `helmetStore.renderStatic()` instead of `Helmet.renderStatic()`.

For people who want to try this feature right now, I have published it to npmjs.
https://www.npmjs.com/package/react-safety-helmet
react-safety-helmet will be deprecated once this PR is accepted.