### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ function HTML () {
                 {helmet.title.toComponent()}
                 {helmet.meta.toComponent()}
                 {helmet.link.toComponent()}
+                {helmet.script.toComponent()}
             </head>
             <body {...bodyAttrs}>
                 <div id="content">


### PR DESCRIPTION
## Description
Making it clearer that script tags will only be rendered with the extra toComponent call.

## Use Case
A window.attribute should be available in a component's componentDidMount(), but when you are Server Side Rendering (SSR) react, and you are missing this extra `script.toComponent()`, you will not have access to global variables.