### PR TITLE
Stack Size Exceeded during shouldComponentUpdate

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -90,9 +90,9 @@ const Helmet = Component =>
         }
 
         shouldComponentUpdate(nextProps) {
-            return Object.keys(HelmetWrapper.propTypes).some(
-                key => !deepEqual(this.props[key], nextProps[key])
-            );
+            const { children, ...props } = this.props;
+            const { children: newChildren, ...newProps } = nextProps;
+            return !deepEqual(this.mapChildrenToProps(children, props), this.mapChildrenToProps(newChildren, newProps));
         }
 
         mapNestedChildrenToProps(child, nestedChildren) {

--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -90,7 +90,9 @@ const Helmet = Component =>
         }
 
         shouldComponentUpdate(nextProps) {
-            return !deepEqual(this.props, nextProps);
+            return Object.keys(HelmetWrapper.propTypes).some(
+                key => !deepEqual(this.props[key], nextProps[key])
+            );
         }
 
         mapNestedChildrenToProps(child, nestedChildren) {


### PR DESCRIPTION
Similar to https://github.com/erikras/redux-form/issues/3461,
and as per mentioned https://github.com/reactjs/reactjs.org/issues/7

I'm suggesting a safer deep equal comparison on the props to be generated.