### PR TITLE
Don't ship tests in npm module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@ CHANGELOG.md
 CONTRIBUTING.md
 coverage
 karma.config.js
-lib/test
+test/
 node_modules
 src
 travis.yml


### PR DESCRIPTION
It looks like this was already in place at some point but got lost when files were reshuffled.