### PR TITLE
Fix titleTemplate example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ function HTML () {
         <Helmet
             titleTemplate="%s | MyAwesomeWebsite.com"
         >
-            <title>My Title</title>
+            <title>Nested Title</title>
         </Helmet>
 
         outputs:


### PR DESCRIPTION
Self explanatory, the example's copy is slightly off.