### PR TITLE
added test for #408

### DIFF
--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -109,6 +109,27 @@ describe("Helmet", () => {
                 });
             });
 
+            it("uses a titleTemplate and a child <title>", done => {
+                ReactDOM.render(
+                    <Helmet
+                        defaultTitle={"Fallback"}
+                        titleTemplate={
+                            "This is a %s of the titleTemplate feature"
+                        }
+                    >
+                        <title>Test</title>
+                    </Helmet>,
+                    container
+                );
+
+                requestAnimationFrame(() => {
+                    expect(document.title).to.equal(
+                        "This is a Test of the titleTemplate feature"
+                    );
+                    done();
+                });
+            });
+
             it("uses a titleTemplate if defined", done => {
                 ReactDOM.render(
                     <Helmet


### PR DESCRIPTION
This adds a previous uncovered test? for #408

i.e. a Helmet child has the `title` for the `titleTemplate`