### PR TITLE
Fixed Nested Title Test

### DIFF
--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -62,7 +62,9 @@ describe("Helmet", () => {
                 ReactDOM.render(
                     <div>
                         <Helmet title={"Main Title"} />
-                        <Helmet title={"Nested Title"} />
+                        <div>
+                            <Helmet title={"Nested Title"} />
+                        </div>
                     </div>,
                     container
                 );


### PR DESCRIPTION
There was a title test that was described as testing for "deeply nested titles" but was testing the same thing as the previous test "updates page title with multiple children". Based on the test description I assume this is what it was intending to test but if not I could see this being removed because of the duplication with updates page title with multiple children test. 