### PR TITLE
Fix hot reload in IE/Edge strict mode

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -274,7 +274,8 @@ const rafPolyfill = (() => {
 const cafPolyfill = (id: string | number) => clearTimeout(id);
 
 const requestAnimationFrame = typeof window !== "undefined"
-    ? window.requestAnimationFrame ||
+    ? (window.requestAnimationFrame &&
+          window.requestAnimationFrame.bind(window)) ||
           window.webkitRequestAnimationFrame ||
           window.mozRequestAnimationFrame ||
           rafPolyfill


### PR DESCRIPTION
Fixes #336

Inspired by https://github.com/vuejs/vue/pull/4725

The background in short:

IE11/Edge will fail when calling `requestAnimationFrame` from `eval`ed code. Webpack hot loading uses `eval` by default.
This issue is *not* React Helmet's fault, but devs using Helmet are facing the issue.

Other libs were so kind as to implement a workaround.
A fair bit of details can be found here: https://github.com/vuejs/vue/issues/4465 (also referenced in the issue)

I'm totally fine with closing this PR as WONTFIX, but if doing so I suggest to also close #336.