### PR TITLE
[package.json] Add "module" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A document head manager for React",
   "version": "6.0.0-beta",
   "main": "./lib/Helmet.js",
+  "module": "./es/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [
     "Chris Welch <chris.welch@nfl.com>",


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/nfl/react-helmet/issues/403#issuecomment-425990450) on #403, the module field in package.json is a hint to bundlers (webpack, rollup, et al) to use the ES Module version of a package, when one is available.

Currently, by default, anybody using webpack is not getting the benefits of the ES Module build-- they're pulling in the CommonJS build.