### PR TITLE
Node v. 9 & 10 .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 node_js:
   - 'node'
+  - 10
+  - 9
   - 8
   - 7
   - 6


### PR DESCRIPTION
As Node versions 9 and 10 were released, they should be included in the .travis.yml file.