### PR TITLE
Fix compatibility with React 16.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="5.2.2"></a>
+## [5.2.2](https://github.com/nfl/react-helmet/compare/5.2.1...5.2.2) (2019-09-15)
+
+
+### Bug Fixes
+
+* Fix compatibility with React 16.9 ([#472](https://github.com/nfl/react-helmet/pull/472)), closes [#465](https://github.com/nfl/react-helmet/issues/465) [#426](https://github.com/nfl/react-helmet/issues/426) [#413](https://github.com/nfl/react-helmet/issues/413)
+
+
+
 <a name="5.2.1"></a>
 # [5.2.1](https://github.com/nfl/react-helmet/compare/5.2.0...5.2.1) (2019-03)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3252,11 +3252,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -7316,13 +7311,9 @@
       "integrity": "sha512-EdPU5vXIzvNvQFNuej3oQ1PZ6YmDunTPZJ3V5EmwRqOhEmW0PNxzUdbYhXnZKZFtrrjGiu9718f6iQRdj0l2JA=="
     },
     "react-side-effect": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
-      "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
-      "requires": {
-        "exenv": "^1.2.1",
-        "shallowequal": "^1.0.1"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -8014,11 +8005,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-helmet",
   "description": "A document head manager for React",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "main": "./lib/Helmet.js",
   "author": "NFL <engineers@nfl.com>",
   "contributors": [
@@ -33,7 +33,7 @@
     "object-assign": "^4.1.1",
     "prop-types": "^15.5.4",
     "react-fast-compare": "^2.0.2",
-    "react-side-effect": "^1.1.0"
+    "react-side-effect": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",


### PR DESCRIPTION
Fix for #465, #426 and #413 by updating react-side-effect to [v2.0.0](https://github.com/gaearon/react-side-effect/releases/tag/v2.0.0) since it's now using `UNSAFE_componentWillMount` instead of `componentWillMount`.

