### PR TITLE
Fix: Travis CI being unable to start GUI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 
+dist: xenial
+
+services:
+  - xvfb
+
 node_js:
   - 'node'
   - 10
@@ -10,8 +15,6 @@ node_js:
 
 before_install:
   - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: node_js
 
-dist: xenial
-
 services:
   - xvfb
 
 addons:
-  chrome: stable
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 
 node_js:
   - 'node'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: xenial
 services:
   - xvfb
 
+addons:
+  chrome: stable
+
 node_js:
   - 'node'
   - 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ node_js:
   - 6
 
 before_install:
-  - export CHROME_BIN=chromium-browser
+  - export CHROME_BIN=/usr/bin/google-chrome
 
 cache:
   yarn: true


### PR DESCRIPTION
Travis CI updated their Ubuntu environment from Trusty to 'Xenial.' 

This brings about a few breaking changes to existing configs with regards to starting xvfb and retrieving google chrome from apt.  