### PR TITLE
Remove extraneous argument

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -584,8 +584,7 @@ const getMethodsForTag = (type, tags, encode) => {
                     generateTitleAsReactComponent(
                         type,
                         tags.title,
-                        tags.titleAttributes,
-                        encode
+                        tags.titleAttributes
                     ),
                 toString: () =>
                     generateTitleAsString(


### PR DESCRIPTION
generateTitleAsReactComponent takes three arguments, as defined a little above. Remove the extra `encode` 4th argument.