### PR TITLE
Adding comment insertion points

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,70 @@ outputs:
 </head>
 ```
 
+### Injection Points
+
+By adding comments to your header you can specify injection points.
+
+```html
+<head>
+    <!-- react-helmet-meta: google-site-verification -->
+    <!-- react-helmet-script: application/ld+json -->
+    <!-- react-helmet-meta: description -->
+    <!-- react-helmet-meta: default -->
+    <!-- react-helmet-link: default -->
+    <!-- react-helmet: default -->
+</head>
+```
+
+```javascript
+import React from "react";
+import {Helmet} from "react-helmet";
+
+class Application extends React.Component {
+  render () {
+    return (
+        <div className="application">
+            <Helmet>
+                <meta name="google-site-verification" content="##########" />
+                <meta name="description" content="Nested component">
+                <meta name="author" content="react-helmet" />
+                <link rel="canonical" href="http://mysite.com/example" />
+                <script type="application/ld+json">"{'@type':'some kind of structured data'}"</script>
+                <noscript>"noscript of some kind"</noscript>
+            </Helmet>
+            ...
+        </div>
+    );
+  }
+};
+```
+
+outputs:
+
+```html
+<head>
+    <!-- react-helmet-meta: google-site-verification -->
+    <meta name="google-site-verification" content="##########">
+    <!-- react-helmet-script: application/ld+json -->
+    <script type="application/ld+json">
+        {'@type':'some kind of structured data'}
+    </script>
+    <!-- react-helmet-meta: description -->
+    <meta name="description" content="Nested component">
+    <!-- react-helmet-meta: default -->
+    <meta name="author" content="react-helmet">
+    <!-- react-helmet-link: default -->
+    <link rel="canonical" href="http://mysite.com/example" />
+    <!-- react-helmet: default -->
+    <noscript>noscript of some kind</noscript>
+</head>
+```
+
 See below for a full reference guide.
 
 ## Features
 - Supports all valid head tags: `title`, `base`, `meta`, `link`, `script`, `noscript`, and `style` tags.
+- Supports comment insertion points
 - Supports attributes for `body`, `html` and `title` tags.
 - Supports server-side rendering.
 - Nested components override duplicate head changes.

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -207,10 +207,7 @@ const getInnermostProperty = (propsList, property) => {
 };
 
 const reducePropsToState = propsList => ({
-    baseTag: getBaseTagFromPropsList(
-        [TAG_PROPERTIES.HREF, TAG_PROPERTIES.TARGET],
-        propsList
-    ),
+    baseTag: getBaseTagFromPropsList([TAG_PROPERTIES.HREF, TAG_PROPERTIES.TARGET], propsList),
     bodyAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.BODY, propsList),
     defer: getInnermostProperty(propsList, HELMET_PROPS.DEFER),
     encode: getInnermostProperty(
@@ -276,22 +273,20 @@ const rafPolyfill = (() => {
 
 const cafPolyfill = (id: string | number) => clearTimeout(id);
 
-const requestAnimationFrame =
-    typeof window !== "undefined"
-        ? (window.requestAnimationFrame &&
-              window.requestAnimationFrame.bind(window)) ||
+const requestAnimationFrame = typeof window !== "undefined"
+    ? (window.requestAnimationFrame &&
+          window.requestAnimationFrame.bind(window)) ||
           window.webkitRequestAnimationFrame ||
           window.mozRequestAnimationFrame ||
           rafPolyfill
-        : global.requestAnimationFrame || rafPolyfill;
+    : global.requestAnimationFrame || rafPolyfill;
 
-const cancelAnimationFrame =
-    typeof window !== "undefined"
-        ? window.cancelAnimationFrame ||
-          window.webkitCancelAnimationFrame ||
-          window.mozCancelAnimationFrame ||
-          cafPolyfill
-        : global.cancelAnimationFrame || cafPolyfill;
+const cancelAnimationFrame = typeof window !== "undefined"
+    ? window.cancelAnimationFrame ||
+        window.webkitCancelAnimationFrame ||
+        window.mozCancelAnimationFrame ||
+        cafPolyfill
+    : global.cancelAnimationFrame || cafPolyfill;
 
 const warn = msg => {
     return console && typeof console.warn === "function" && console.warn(msg);
@@ -509,10 +504,9 @@ const updateTags = (type, tags) => {
                             );
                         }
                     } else {
-                        const value =
-                            typeof tag[attribute] === "undefined"
-                                ? ""
-                                : tag[attribute];
+                        const value = typeof tag[attribute] === "undefined"
+                            ? ""
+                            : tag[attribute];
                         newElement.setAttribute(attribute, value);
                     }
                 }
@@ -545,10 +539,9 @@ const updateTags = (type, tags) => {
 
 const generateElementAttributesAsString = attributes =>
     Object.keys(attributes).reduce((str, key) => {
-        const attr =
-            typeof attributes[key] !== "undefined"
-                ? `${key}="${attributes[key]}"`
-                : `${key}`;
+        const attr = typeof attributes[key] !== "undefined"
+            ? `${key}="${attributes[key]}"`
+            : `${key}`;
         return str ? `${str} ${attr}` : attr;
     }, "");
 
@@ -577,13 +570,12 @@ const generateTagsAsString = (type, tags, encode) =>
                     )
             )
             .reduce((string, attribute) => {
-                const attr =
-                    typeof tag[attribute] === "undefined"
-                        ? attribute
-                        : `${attribute}="${encodeSpecialCharacters(
-                              tag[attribute],
-                              encode
-                          )}"`;
+                const attr = typeof tag[attribute] === "undefined"
+                    ? attribute
+                    : `${attribute}="${encodeSpecialCharacters(
+                            tag[attribute],
+                            encode
+                        )}"`;
                 return string ? `${string} ${attr}` : attr;
             }, "");
 
@@ -591,9 +583,9 @@ const generateTagsAsString = (type, tags, encode) =>
 
         const isSelfClosing = SELF_CLOSING_TAGS.indexOf(type) === -1;
 
-        return `${str}<${type} ${HELMET_ATTRIBUTE}="true" ${attributeHtml}${
-            isSelfClosing ? `/>` : `>${tagContent}</${type}>`
-        }`;
+        return `${str}<${type} ${HELMET_ATTRIBUTE}="true" ${attributeHtml}${isSelfClosing
+            ? `/>`
+            : `>${tagContent}</${type}>`}`;
     }, "");
 
 const convertElementAttributestoReactProps = (attributes, initProps = {}) => {

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -283,9 +283,9 @@ const requestAnimationFrame = typeof window !== "undefined"
 
 const cancelAnimationFrame = typeof window !== "undefined"
     ? window.cancelAnimationFrame ||
-        window.webkitCancelAnimationFrame ||
-        window.mozCancelAnimationFrame ||
-        cafPolyfill
+          window.webkitCancelAnimationFrame ||
+          window.mozCancelAnimationFrame ||
+          cafPolyfill
     : global.cancelAnimationFrame || cafPolyfill;
 
 const warn = msg => {
@@ -573,9 +573,9 @@ const generateTagsAsString = (type, tags, encode) =>
                 const attr = typeof tag[attribute] === "undefined"
                     ? attribute
                     : `${attribute}="${encodeSpecialCharacters(
-                            tag[attribute],
-                            encode
-                        )}"`;
+                          tag[attribute],
+                          encode
+                      )}"`;
                 return string ? `${string} ${attr}` : attr;
             }, "");
 


### PR DESCRIPTION
There are instances where header tags need to be placed in other locations in the header other than the bottom. This code change will make it so that you can add comments to your header to dictate where you want react-helmet to insert tags.