### PR TITLE
Support nested title templates

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -26,7 +26,7 @@ const encodeSpecialCharacters = (str, encode = true) => {
 
 const getTitleFromPropsList = propsList => {
     const innermostTitle = getInnermostProperty(propsList, TAG_NAMES.TITLE);
-    const innermostTemplate = getInnermostProperty(
+    const innermostTemplate = getNestedProperty(
         propsList,
         HELMET_PROPS.TITLE_TEMPLATE
     );
@@ -203,6 +203,25 @@ const getInnermostProperty = (propsList, property) => {
         }
     }
 
+    return null;
+};
+
+const getNestedProperty = (propsList, property) => {
+    for (let i = propsList.length - 1; i >= 0; i -= 1) {
+        const props = propsList[i];
+
+        if (Object.prototype.hasOwnProperty.call(props, property)) {
+            if (props[property] && typeof props[property] === "function") {
+                const parent =
+                    getNestedProperty(propsList.slice(0, i), property) || "";
+                return props[property](t => parent.replace(/%s/g, t), {
+                    [property]: parent,
+                    pattern: /%s/g
+                });
+            }
+            return props[property];
+        }
+    }
     return null;
 };
 

--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -291,7 +291,7 @@ describe("Helmet", () => {
                 });
             });
 
-            it("allows titleTemplate property to be nested", done => {
+            it("allows titleTemplate property to be nested with a custom replace function", done => {
                 ReactDOM.render(
                     <div>
                         <Helmet

--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -265,6 +265,64 @@ describe("Helmet", () => {
                 });
             });
 
+            it("allows titleTemplate property to be nested", done => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            title={"Test"}
+                            titleTemplate={"%s | Site Name"}
+                        />
+                        <Helmet
+                            titleTemplate={replace =>
+                                replace(`%s | Section Name`)
+                            }
+                        />
+                        <Helmet title={"Page Name"} />
+                    </div>,
+                    container
+                );
+
+                requestAnimationFrame(() => {
+                    expect(document.title).to.equal(
+                        "Page Name | Section Name | Site Name"
+                    );
+
+                    done();
+                });
+            });
+
+            it("allows titleTemplate property to be nested", done => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            title={"Test"}
+                            titleTemplate={"%s | Site Name"}
+                        />
+                        <Helmet
+                            titleTemplate={replace =>
+                                replace(`%s | Section Name`)
+                            }
+                        />
+                        <Helmet
+                            titleTemplate={(
+                                replace,
+                                {titleTemplate, pattern}
+                            ) => titleTemplate.replace(pattern, "(1) %s")}
+                        />
+                        <Helmet title={"Page Name"} />
+                    </div>,
+                    container
+                );
+
+                requestAnimationFrame(() => {
+                    expect(document.title).to.equal(
+                        "(1) Page Name | Section Name | Site Name"
+                    );
+
+                    done();
+                });
+            });
+
             it("does not encode all characters with HTML character entity equivalents", done => {
                 const chineseTitle = "膣膗 鍆錌雔";
 


### PR DESCRIPTION
Add a `getNestedProperty` util for titleTemplate, allows nested title templates.

Fixes #293

e.g.

https://github.com/nfl/react-helmet/blob/067a35c667e868cf2c49c390bd6ac7c429497b37/test/HelmetTest.js#L271-L280

=> Page Name | Section Name | Site Name

https://github.com/nfl/react-helmet/blob/067a35c667e868cf2c49c390bd6ac7c429497b37/test/HelmetTest.js#L297-L312

=> (1) Page Name | Section Name | Site Name


---
TODO:

Probably need to add similar functionality to defaultTitle, so that you can do the following:
```
		<Helmet
			defaultTitle={`Site Name`}
			titleTemplate={`%s | Site Name`}>
		<Helmet
			defaultTitle={replace =>
                                replace(`Section Name`)
                            }
			titleTemplate={replace =>
                                replace(`%s | Section Name`)
                            }>
```