### PR TITLE
Re-add Helmet as a default export

### DIFF
--- a/src/Helmet.js
+++ b/src/Helmet.js
@@ -294,3 +294,4 @@ const HelmetExport = Helmet(HelmetSideEffects);
 HelmetExport.renderStatic = HelmetExport.rewind;
 
 export {HelmetExport as Helmet};
+export default HelmetExport;


### PR DESCRIPTION
I was in the process of upgrading some packages related to react-redux and react-redux-router (now connected-react-router) and noticed I was getting an "Uncaught RangeError: Maximum call stack size exceeded" as described [here](https://github.com/nfl/react-helmet/issues/373#issuecomment-407982788). After many hours of debugging I found it was coming from react-helmet.

It seemed like upgrading to 6.0.0 fixed the issue but I noticed 6.0.0 removed `Helmet` as a default export. 

> Bundle with Rollup instead of Webpack - As a result, the default export was removed and Helmet must now be imported as a named component

This would require me to change all imports within my app or use some magical alias webpack thing to keep the same import statements. I'm not sure why Rollup would necessitate a change to the API at all but I've added the default export back (in addition to the named export) for backwards compatibility for current v6 users and better forwards compatibility from v5 -> v6.