### PR TITLE
Fix link rel=alternate not overriden from inner component

### DIFF
--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -32,7 +32,8 @@ export const TAG_PROPERTIES = {
     PROPERTY: "property",
     REL: "rel",
     SRC: "src",
-    TARGET: "target"
+    TARGET: "target",
+    HREF_LANG: "hreflang"
 };
 
 export const REACT_TAG_MAP = {
@@ -43,7 +44,8 @@ export const REACT_TAG_MAP = {
     contextmenu: "contextMenu",
     "http-equiv": "httpEquiv",
     itemprop: "itemProp",
-    tabindex: "tabIndex"
+    tabindex: "tabIndex",
+    hreflang: "hrefLang"
 };
 
 export const HELMET_PROPS = {

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -141,6 +141,19 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                         ) {
                             primaryAttributeKey = lowerCaseAttributeKey;
                         }
+
+                        // Special rule with alternate link where hreflang takes priority over rel and href
+                        if (
+                            primaryAttributes.indexOf(
+                                TAG_PROPERTIES.HREF_LANG
+                            ) !== -1 &&
+                            keys.indexOf(TAG_PROPERTIES.REL) !== -1 &&
+                            tag[TAG_PROPERTIES.REL].toLowerCase() ===
+                                "alternate"
+                        ) {
+                            primaryAttributeKey = TAG_PROPERTIES.HREF_LANG;
+                        }
+
                         // Special case for innerHTML which doesn't work lowercased
                         if (
                             primaryAttributes.indexOf(attributeKey) !== -1 &&
@@ -220,7 +233,7 @@ const reducePropsToState = propsList => ({
     htmlAttributes: getAttributesFromPropsList(ATTRIBUTE_NAMES.HTML, propsList),
     linkTags: getTagsFromPropsList(
         TAG_NAMES.LINK,
-        [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF],
+        [TAG_PROPERTIES.REL, TAG_PROPERTIES.HREF, TAG_PROPERTIES.HREF_LANG],
         propsList
     ),
     metaTags: getTagsFromPropsList(

--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -1885,6 +1885,79 @@ describe("Helmet", () => {
                     done();
                 });
             });
+
+            it("overrides one of two links tag rel=alternate with one duplicate link tag in a nested component", done => {
+                ReactDOM.render(
+                    <div>
+                        <Helmet
+                            link={[
+                                {
+                                    hreflang: "en",
+                                    rel: "alternate",
+                                    href: "http://localhost/helmet"
+                                },
+                                {
+                                    rel: "alternate",
+                                    href: "http://localhost/helmet/component",
+                                    hreflang: "it"
+                                }
+                            ]}
+                        />
+                        <Helmet
+                            link={[
+                                {
+                                    rel: "alternate",
+                                    hreflang: "en",
+                                    href:
+                                        "http://localhost/helmet/innercomponent"
+                                }
+                            ]}
+                        />
+                    </div>,
+                    container
+                );
+
+                requestAnimationFrame(() => {
+                    const tagNodes = headElement.querySelectorAll(
+                        `link[${HELMET_ATTRIBUTE}]`
+                    );
+                    const existingTags = Array.prototype.slice.call(tagNodes);
+                    const firstTag = existingTags[0];
+                    const secondTag = existingTags[1];
+
+                    expect(existingTags).to.not.equal(undefined);
+
+                    expect(existingTags.length).to.be.equal(2);
+
+                    expect(existingTags).to.have.deep
+                        .property("[0]")
+                        .that.is.an.instanceof(Element);
+                    expect(firstTag).to.have.property("getAttribute");
+                    expect(firstTag.getAttribute("rel")).to.equal("alternate");
+                    expect(firstTag.getAttribute("hreflang")).to.equal("it");
+                    expect(firstTag.getAttribute("href")).to.equal(
+                        "http://localhost/helmet/component"
+                    );
+                    expect(firstTag.outerHTML).to.equal(
+                        `<link rel="alternate" href="http://localhost/helmet/component" hreflang="it" ${HELMET_ATTRIBUTE}="true">`
+                    );
+
+                    expect(existingTags).to.have.deep
+                        .property("[1]")
+                        .that.is.an.instanceof(Element);
+                    expect(secondTag).to.have.property("getAttribute");
+                    expect(secondTag.getAttribute("rel")).to.equal("alternate");
+                    expect(secondTag.getAttribute("hreflang")).to.equal("en");
+                    expect(secondTag.getAttribute("href")).to.equal(
+                        "http://localhost/helmet/innercomponent"
+                    );
+                    expect(secondTag.outerHTML).to.equal(
+                        `<link rel="alternate" hreflang="en" href="http://localhost/helmet/innercomponent" ${HELMET_ATTRIBUTE}="true">`
+                    );
+
+                    done();
+                });
+            });
         });
 
         describe("script tags", () => {


### PR DESCRIPTION
The fix allow Link rel="alternate" override in inner component based on hreflang. 
There is one new test for this use case.


The readme file example below let me assume that it was overriden using the key attribute:
```
{locales.map((locale) => {
        <link rel="alternate" href="http://example.com/{locale}" hrefLang={locale} key={locale}/>
    })}
```

Below, the use case I had for a given locale "en"
In a component you add `<link rel="alternate" href="http://example.com/en" hrefLang="en" key="en"/>`
In an inner component you add `<link rel="alternate" href="http://www.example.com/page/en" hrefLang="en" key="en"/>`

I was exepecting to have only the one from the inner component.
But the actual result was both link. 




