### PR TITLE
Simplify VALID_TAG_NAMES definition

### DIFF
--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -17,9 +17,7 @@ export const TAG_NAMES = {
     TITLE: "title"
 };
 
-export const VALID_TAG_NAMES = Object.keys(TAG_NAMES).map(
-    name => TAG_NAMES[name]
-);
+export const VALID_TAG_NAMES = Object.values(TAG_NAMES);
 
 export const TAG_PROPERTIES = {
     CHARSET: "charset",


### PR DESCRIPTION
Hi all 👋  this is a small one, just cleans up the definition of the `VALID_TAG_NAMES` array. Not sure if there's a reason to use `Object.keys` if the goal is to get an array of values anyways.