### PR TITLE
Support non-string exports responsive-loader

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -156,6 +156,14 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                         return false;
                     }
 
+                    // ISSUE: TypeError: tag[primaryAttributeKey].toLowerCase is not a function
+                    // when together with https://github.com/dazuaz/responsive-loader
+                    if ( typeof tag[primaryAttributeKey] === "object" && tag[primaryAttributeKey].hasOwnProperty("src") ) {
+                        tag[primaryAttributeKey] = tag[primaryAttributeKey].src;
+                    }
+                    if ( typeof tag[primaryAttributeKey] !== "string" ) {
+                        return false;
+                    }
                     const value = tag[primaryAttributeKey].toLowerCase();
 
                     if (!approvedSeenTags[primaryAttributeKey]) {


### PR DESCRIPTION
Module https://github.com/dazuaz/responsive-loader exports images as an object like { src: "", srcSet: ", ..}. Helmet expects a string and therefore crushes as: TypeError: tag[primaryAttributeKey].toLowerCase is not a function