### PR TITLE
Set boolean attributes as empty strings

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -448,10 +448,11 @@ const updateTags = (type, tags) => {
                             );
                         }
                     } else {
-                        const value =
-                            typeof tag[attribute] === "undefined"
-                                ? ""
-                                : tag[attribute];
+                        const value = ["undefined", "boolean"].includes(
+                            typeof tag[attribute]
+                        )
+                            ? ""
+                            : tag[attribute];
                         newElement.setAttribute(attribute, value);
                     }
                 }

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -2266,6 +2266,30 @@ describe("Helmet - Declarative API", () => {
                 });
             });
 
+            it("sets boolean attribute values to empty strings", done => {
+                ReactDOM.render(
+                    <Helmet>
+                        <script src="foo.js" async />
+                    </Helmet>,
+                    container
+                );
+
+                requestAnimationFrame(() => {
+                    const existingTag = headElement.querySelector(
+                        `script[${HELMET_ATTRIBUTE}]`
+                    );
+
+                    expect(existingTag).to.not.equal(undefined);
+                    expect(existingTag.outerHTML).to.be
+                        .a("string")
+                        .that.equals(
+                            `<script src="foo.js" async="" ${HELMET_ATTRIBUTE}="true"></script>`
+                        );
+
+                    done();
+                });
+            });
+
             it("does not render tag when primary attribute (src) is null", done => {
                 ReactDOM.render(
                     <Helmet>


### PR DESCRIPTION
When using react-helmet with SSR we're seeing issues with elements being re-rendered in the browser due to the difference in how boolean attributes are rendered. This is especially problematic for async scripts, which can then run twice.

If we use `renderToStaticMarkup()` to render the server-side markup boolean attributes are rendered as empty strings, for example:

```
const el = React.createElement('script', { async: true });
console.log(ReactDOM.renderToStaticMarkup(el));
// => <script async=""></script>
```
https://github.com/facebook/react/blob/9198a5cec0936a21a5ba194a22fcbac03eba5d1d/packages/react-dom/src/client/DOMPropertyOperations.js#L187

Helmet uses `Element.setAttribute()` directly, without the extra stuff React does to modify these attributes, so boolean attributes are set as their stringified values, like:

```
const el = document.createElement('script');
el.setAttribute('async', true);
console.log(el);
// => <script async="true"></script>
```

It seems the difference between these two outputs is enough to cause the element to re-render.