### PR TITLE
Fix link alternate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Or to import the *react-helmet* instance from the app on the server.
     <link rel="apple-touch-icon" href="http://mysite.com/img/apple-touch-icon-57x57.png" />
     <link rel="apple-touch-icon" sizes="72x72" href="http://mysite.com/img/apple-touch-icon-72x72.png" />
     {locales.map((locale) => {
-        <link rel="alternate" href="http://example.com/{locale}" hrefLang={locale} key={locale}/>
+        return <link rel="alternate" href="http://example.com/{locale}" hrefLang={locale} key={locale}/>;
     })}
 
     {/* multiple script elements */}


### PR DESCRIPTION
Without returning the link tag it won't be mapped, thus not appear in the head.