### PR TITLE
Add support for sorting metatags by data-order

### DIFF
--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -65,4 +65,4 @@ export const SELF_CLOSING_TAGS = [
 
 export const HELMET_ATTRIBUTE = "data-react-helmet";
 
-export const VERY_LOW_NUMBER = -99999999999;
+export const VERY_LOW_NUMBER = -9999999999;

--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -64,3 +64,5 @@ export const SELF_CLOSING_TAGS = [
 ];
 
 export const HELMET_ATTRIBUTE = "data-react-helmet";
+
+export const VERY_LOW_NUMBER = -99999999999;

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -8,7 +8,8 @@ import {
     REACT_TAG_MAP,
     SELF_CLOSING_TAGS,
     TAG_NAMES,
-    TAG_PROPERTIES
+    TAG_PROPERTIES,
+    VERY_LOW_NUMBER
 } from "./HelmetConstants.js";
 
 const encodeSpecialCharacters = (str, encode = true) => {
@@ -475,6 +476,25 @@ const updateTags = (type, tags) => {
 
     oldTags.forEach(tag => tag.parentNode.removeChild(tag));
     newTags.forEach(tag => headElement.appendChild(tag));
+
+    if (type === 'meta') {
+        let isSorting = true;
+        while (isSorting) {
+            isSorting = false;
+
+            const metaTags = headElement.querySelectorAll('meta');
+            for (let i = 0; i < metaTags.length - 1; i++) {
+                const orderValueA = +metaTags[i].dataset.order || VERY_LOW_NUMBER;
+                const orderValueB = +metaTags[i + 1].dataset.order || VERY_LOW_NUMBER;
+
+                if (orderValueA > orderValueB) {
+                    headElement.insertBefore(metaTags[i + 1], metaTags[i]);
+                    isSorting = true;
+                    break;
+                }
+            }
+        }
+    }
 
     return {
         oldTags,


### PR DESCRIPTION
When working with social sharing tags, you may need fallback images for `og:image` and similar. 
Facebook crawler looks at the order of metatags, so it is important when having multiple of the same tag that the ordering is correct.