### PR TITLE
Ensure "data-react-helmet" always renders its value as "true"

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -553,7 +553,7 @@ const generateTitleAsReactComponent = (type, title, attributes) => {
     // assigning into an array to define toString function on it
     const initProps = {
         key: title,
-        [HELMET_ATTRIBUTE]: true
+        [HELMET_ATTRIBUTE]: "true"
     };
     const props = convertElementAttributestoReactProps(attributes, initProps);
 
@@ -564,7 +564,7 @@ const generateTagsAsReactComponent = (type, tags) =>
     tags.map((tag, i) => {
         const mappedTag = {
             key: i,
-            [HELMET_ATTRIBUTE]: true
+            [HELMET_ATTRIBUTE]: "true"
         };
 
         Object.keys(tag).forEach(attribute => {


### PR DESCRIPTION
The value of "data-react-helmet" attribute is set several times and in several contexts across react-helmet. In all cases is set as a string (`"true"`), except in `generateTitleAsReactComponent()` and `generateTagsAsReactComponent()`, where it's value is a boolean (`true`).

This _subtle inconsistency_ has no effect in most cases, except when using Preact + preact-compat:

- React renders a boolean value as `data-react-helmet="true"` (it might change in the future)
- Preact renders a boolean value as `data-react-helmet` (it might change in the future)

Both are valid syntax, but I have encountered that some social media scrappers (like Whatsapp) do not understand a meta tag if it contains an empty data attribute. Hence, `<meta data-react-helmet property="og:title" content="My title" />` is considered incorrect and thus not parsed.

We should ensure the consistency of values for that data attribute, to ensure it's always rendered the same way, regardless the fact of using React of Preact. At this moment, it's relaying on React's interpretation of boolean values, that could be changed in the future, which could lead to unexpected results.