### PR TITLE
primaryAttributeKey check for string

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -152,7 +152,11 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                         }
                     }
 
-                    if (!primaryAttributeKey || !tag[primaryAttributeKey]) {
+                    if (
+                        !primaryAttributeKey ||
+                        !tag[primaryAttributeKey] ||
+                        typeof tag[primaryAttributeKey] !== "string"
+                    ) {
                         return false;
                     }
 


### PR DESCRIPTION
If tag[primaryAttributeKey] is not string, it should return false. Since, In many cases we have tag[primaryAttributeKey] as object.

We get this error if the attr is an object 
`TypeError: tag[primaryAttributeKey].toLowerCase is not a function
    at /node_modules/react-helmet/lib/HelmetUtils.js:124:100
    at Array.filter (<anonymous>)
    at /node_modules/react-helmet/lib/HelmetUtils.js:100:22
    at Array.reduce (<anonymous>)
    at getTagsFromPropsList (/node_modules/react-helmet/lib/HelmetUtils.js:97:18)
    at reducePropsToState (/node_modules/react-helmet/lib/HelmetUtils.js:181:19)`