### PR TITLE
Fix: async property of scripts is not assigned properly

### DIFF
--- a/src/HelmetConstants.js
+++ b/src/HelmetConstants.js
@@ -30,7 +30,8 @@ export const TAG_PROPERTIES = {
     PROPERTY: "property",
     REL: "rel",
     SRC: "src",
-    TARGET: "target"
+    TARGET: "target",
+    ASYNC: "async"
 };
 
 export const REACT_TAG_MAP = {

--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -454,6 +454,14 @@ const updateTags = (type, tags) => {
                                 : tag[attribute];
                         newElement.setAttribute(attribute, value);
                     }
+
+                    // The async attribute is ignored on dynamic scripts, the property must be set directly
+                    if (
+                        attribute === TAG_PROPERTIES.ASYNC &&
+                        typeof tag.async === "boolean"
+                    ) {
+                        newElement.async = tag.async;
+                    }
                 }
             }
 

--- a/test/HelmetDeclarativeTest.js
+++ b/test/HelmetDeclarativeTest.js
@@ -3732,5 +3732,34 @@ describe("Helmet - Declarative API", () => {
                 done();
             });
         });
+
+        it("correctly assigns the async property to a script tag", done => {
+            const spy = sinon.spy();
+            ReactDOM.render(
+                <Helmet
+                    script={[
+                        {
+                            src: "http://localhost/test.js",
+                            type: "text/javascript",
+                            async: false
+                        }
+                    ]}
+                    onChangeClientState={spy}
+                />,
+                container
+            );
+
+            requestAnimationFrame(() => {
+                expect(spy.called).to.equal(true);
+
+                const [, addedTags] = spy.getCall(0).args;
+
+                expect(addedTags).to.have.property("scriptTags");
+                expect(addedTags.scriptTags).to.have.deep.property("[0]");
+                expect(addedTags.scriptTags[0].async).to.equal(false);
+
+                done();
+            });
+        });
     });
 });

--- a/test/HelmetTest.js
+++ b/test/HelmetTest.js
@@ -3399,5 +3399,34 @@ describe("Helmet", () => {
                 done();
             });
         });
+
+        it("correctly assigns the async property to a script tag", done => {
+            const spy = sinon.spy();
+            ReactDOM.render(
+                <Helmet
+                    script={[
+                        {
+                            src: "http://localhost/test.js",
+                            type: "text/javascript",
+                            async: false
+                        }
+                    ]}
+                    onChangeClientState={spy}
+                />,
+                container
+            );
+
+            requestAnimationFrame(() => {
+                expect(spy.called).to.equal(true);
+
+                const [, addedTags] = spy.getCall(0).args;
+
+                expect(addedTags).to.have.property("scriptTags");
+                expect(addedTags.scriptTags).to.have.deep.property("[0]");
+                expect(addedTags.scriptTags[0].async).to.equal(false);
+
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
This fix addresses a problem that happens when trying to set the `async` attribute of a script tag.
Intuitively, setting the `async` attribute on the tag should also set the the element `async` property. However this is not the case.

This not a bug but part of the specification.
The `async` attribute is used only by the HTML/XML parser when the page is initially loaded, but it's ignored on dynamic scripts, which are async by default (you can check the section about "force-async": https://www.w3.org/TR/2014/PR-html5-20140916/scripting-1.html ).

For this reason `script.setAttribute('async', value)` will not work as expected.
In order to actually change the async behavior of the tag, the property must be set directly with `script.async = value`. 

Setting `async=false` is particularly useful to maintain the execution order of dynamic scripts.
Inside issue #419 someone actually suggested this solution, but when I tried some code like the following one the tags executed out of order most of the time.

```jsx
<Helmet>
  <script async={false} src="big-file.js" />
  <script async={false} src="small-file.js" /> 
</Helmet>
```

Related issues: #419 