### PR TITLE
fix: letter's capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Nested or latter components will override duplicate changes:
 </Parent>
 ```
 
-outputs:
+Outputs:
 
 ```html
 <head>


### PR DESCRIPTION
"outputs:" line should start with a capital letter as any other line does

![image](https://user-images.githubusercontent.com/6383738/175800662-20ad07c1-e633-4ff6-8743-a6270650fa0b.png)
