### PR TITLE
Fixed determining primary attribute key for meta tags

### DIFF
--- a/src/HelmetUtils.js
+++ b/src/HelmetUtils.js
@@ -128,6 +128,7 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                         if (
                             primaryAttributes.indexOf(lowerCaseAttributeKey) !==
                                 -1 &&
+                            tag[lowerCaseAttributeKey] &&
                             !(
                                 primaryAttributeKey === TAG_PROPERTIES.REL &&
                                 tag[primaryAttributeKey].toLowerCase() ===
@@ -144,6 +145,7 @@ const getTagsFromPropsList = (tagName, primaryAttributes, propsList) => {
                         // Special case for innerHTML which doesn't work lowercased
                         if (
                             primaryAttributes.indexOf(attributeKey) !== -1 &&
+                            tag[attributeKey] &&
                             (attributeKey === TAG_PROPERTIES.INNER_HTML ||
                                 attributeKey === TAG_PROPERTIES.CSS_TEXT ||
                                 attributeKey === TAG_PROPERTIES.ITEM_PROP)


### PR DESCRIPTION
## Problem / Motivation

`primaryAttributeKey` is set to the last item in the `primaryAttributes` array which matches the conditions. If the last property value is `null`, the whole meta tag will be discarded.

An example: `<meta content={'some-content'} property={'some-value'} name={null} />`. Here `primaryAttributeKey` will be set to `name` (as it is last in the list of properties), and then the meta tag will not be rendered as `name` is `null`.

## Proposed solution
To avoid such situations we should consider only properties with non-false values as candidates for `primaryAttributeKey`.